### PR TITLE
Handles anchors on directory pages

### DIFF
--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -19,7 +19,7 @@
 	{{ range $pages }}
 	{{ $path := trim . " \n" }}
 	{{ $anchor := index ( split $path "#" ) 1 }}
-	{{ $path := index ( split $path "#" ) 0 }}
+	{{ $path := strings.TrimRight "/" ( index ( split $path "#" ) 0 ) }}
 	{{ $page := $.Site.GetPage $path }}
 	{{ if not $page }}
 	{{ if (eq $.Site.Params.linkErrorLevel "WARNING") }}


### PR DESCRIPTION
Anchors on directories were not being resolved for the relatedContent field. With this change anchors on pages with trailing slashes, like `core/overview/db-schema/#targets`, will work.