### PR TITLE
Update software support policy

### DIFF
--- a/content/en/core/overview/supported-software.md
+++ b/content/en/core/overview/supported-software.md
@@ -7,30 +7,23 @@ description: >
 relevantLinks: >
 ---
 
-Medic Mobile supports the latest patch of minor versions of the Core Framework for three months after the next minor version is made available, and the latest minor of a major version for twelve months after the next major version is made available.
+Medic Mobile supports minor versions of the Core Framework for three months after the next minor version is made available, and the latest minor of a major version for twelve months after the next major version is made available.
 
 Once a version is no longer supported it will not receive any further releases and upgrading may be required before Medic Mobile can investigate any issues.
 
 | Version | Status | Release date | End of life |
 |----|----|----|----|
-| 3.9.0 | Current | 19-Jun-2020 | TBA |
-| 3.8.1 | Current | 6-Apr-2020 | 19-Sep-2020 |
-| 3.8.0 | EOL | 11-Feb-2020 | 6-Apr-2020 |
-| 3.7.1 | EOL | 13-Nov-2019 | 11-Jun-2020 |
-| 3.7.0 | EOL | 22-Oct-2019 | 13-Nov-2019 |
-| 3.6.2 | EOL | 24-Mar-2020 | 24-Mar-2020 |
-| 3.6.1 | EOL | 07-Aug-2019 | 22-Jan-2020 |
-| 3.6.0 | EOL | 17-Jul-2019 | 07-Aug-2019 |
-| 3.5.0 | EOL | 27-Jun-2019 | 17-Oct-2019 |
-| 3.4.1 | EOL | 4-Jun-2019 | 27-Sep-2019 |
-| 3.4.0 | EOL | 27-Mar-2019 | 4-Jun-2019 |
-| 3.3.0 | EOL | 22-Feb-2019 | 27-Jun-2019 |
-| 3.2.1 | EOL | 23-Jan-2019 | 22-May-2019 |
-| 3.2.0 | EOL | 23-Jan-2019 | 23-Jan-2019 |
-| 3.1.0 | EOL | 21-Nov-2018 | 23-Apr-2019 |
-| 3.0.0 | EOL | 15-Nov-2018 | 21-Feb-2019 |
-| 2.18.1 | EOL | 31-Oct-2018 | 15-Nov-2019 |
-| 2.18.0 | EOL | 30-Aug-2018 | 31-Oct-2018 |
+| 3.9.x | Current | 19-Jun-2020 | TBA |
+| 3.8.x | Current | 11-Feb-2020 | 19-Sep-2020 |
+| 3.7.x | EOL | 22-Oct-2019 | 11-Jun-2020 |
+| 3.6.x | EOL | 17-Jul-2019 | 24-Mar-2020 |
+| 3.5.x | EOL | 27-Jun-2019 | 17-Oct-2019 |
+| 3.4.x | EOL | 27-Mar-2019 | 27-Sep-2019 |
+| 3.3.x | EOL | 22-Feb-2019 | 27-Jun-2019 |
+| 3.2.x | EOL | 23-Jan-2019 | 22-May-2019 |
+| 3.1.x | EOL | 21-Nov-2018 | 23-Apr-2019 |
+| 3.0.x | EOL | 15-Nov-2018 | 21-Feb-2019 |
+| 2.18.x | EOL | 30-Aug-2018 | 15-Nov-2019 |
 | earlier | EOL | ... | 30-Nov-2018 |
 
 # Dependencies


### PR DESCRIPTION
Now we support all patches for a minor, instead of just the latest patch,
for 3 months after the subsequent minor is released.