### PR TITLE
stop see-also shortcode from always showing an anchor

### DIFF
--- a/layouts/shortcodes/see-also.html
+++ b/layouts/shortcodes/see-also.html
@@ -1,3 +1,8 @@
+<!--
+    This is technically identical to the 'read-more` template, but used differently. That said, likely
+    the styles for both should be kept in sync.
+    See https://github.com/medic/cht-docs/pull/203 for context
+-->
 {{ $page := .Get "page" }}
 {{ $anchor := .Get "anchor" }}
 {{ $save := . }}
@@ -10,9 +15,13 @@
 {{ end }}
 {{ with $.Site.GetPage $page }}
 {{ $title := $save.Get "title" }}
-{{ if $title }}
+{{ if and ($title) ($anchor) }}
 {{ printf "<p><em>See Also:</em> <a href=%s#%s>%s</a></p>" (ref . $page) $anchor $title | safeHTML }}
-{{ else }}
+{{ else if $title }}
+{{ printf "<p><em>See Also:</em> <a href=%s>%s</a></p>" (ref . $page) $title | safeHTML }}
+{{ else if $anchor }}
 {{ (printf "<p><em>See Also:</em> <a href=%s#%s>%s</a></p>" (ref . $page) $anchor .Title) | safeHTML }}
+{{ else }}
+{{ (printf "<p><em>See Also:</em> <a href=%s>%s</a></p>" (ref . $page) .Title) | safeHTML }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
we should be sure to test:
* basic `{{< see-also page="design/icons" >}}`
* basic with title  `{{< see-also page="design/icons" title="Learn about the Icon Library" >}}`
* basic with anchor  `{{< see-also page="design/icons"  anchor="about-the-icon-library"  >}}`
* basic with title and anchor  `{{< see-also page="design/icons"  title="Learn about the Icon Library" anchor="about-the-icon-library"  >}}`