### PR TITLE
211 - Shows documentation search results first

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 <section class="row td-search-result">
-<div class="col-12 col-md-8">{{/* Only change is to remove offset to match content pages */}}
+<div class="col-12 col-xl-10">
 <h2 class="ml-4">{{ .Title }}</h2>
 {{ with .Site.Params.gcs_engine_id }}
 <script>
@@ -14,7 +14,7 @@ var s = document.getElementsByTagName('script')[0];
 s.parentNode.insertBefore(gcse, s);
 })();
 </script>
-			<gcse:searchresults-only></gcse:searchresults-only>
+			<gcse:searchresults-only defaultToRefinement="Documentation"></gcse:searchresults-only>
 {{ end }}
 </div>
 </section>


### PR DESCRIPTION
The search now shows the results for the _Documentation_ first. @n-orlowski and I looked at other options of having a primary and secondary search, and in the end we were happy to have a clean way to have highlight the primary search, yet still making the secondary search available. 

For #211 