### PR TITLE
Hide item from menu

### DIFF
--- a/content/en/apps/reference/_partial_functions.md
+++ b/content/en/apps/reference/_partial_functions.md
@@ -1,3 +1,8 @@
+---
+title: "Utils Functions"
+toc_hide: true
+---
+
 ## Utils
 Utility functions in the Core Framework can make common tasks much easier. These are available only for Tasks and Targets. To use the function call `Utils.<function-name>(<params>)`, for example `Utils.addDate(report.reported_date, 10)`.
 

--- a/content/en/apps/reference/_partial_utils.md
+++ b/content/en/apps/reference/_partial_utils.md
@@ -3,7 +3,6 @@ title: "Utils Functions"
 toc_hide: true
 ---
 
-## Utils
 Utility functions in the Core Framework can make common tasks much easier. These are available only for Tasks and Targets. To use the function call `Utils.<function-name>(<params>)`, for example `Utils.addDate(report.reported_date, 10)`.
 
 | Name | Description |
@@ -22,12 +21,4 @@ Utility functions in the Core Framework can make common tasks much easier. These
 
 Please open [an issue](https://github.com/medic/cht-core/issues/new) if you'd like other functions included.
 
-## Nools Extras
-Helper variables and functions can be defined in `nools-extras.js`, which is shared by both `tasks.js` and `targets.js`. The following are global variables that can be used:
-
-| Variable | Description |
-|---|---|
-| `c.contact` | The contact's doc. All contacts have `type` of either `person` or `place`.
-| `c.reports` | An array of all the reports submitted about the contact.
-| `console` | Useful for outputting _debugging_ statements. Should not be used in production code. |
-| `Utils` | Useful functions across projects are available, and describe in the Utils section. |
+Custom functions and variables can be written in [`nools-extra.js`]({{< ref "apps/reference/nools-extras" >}}), which is accessible to both Targets and Tasks.

--- a/content/en/apps/reference/nools-extras.md
+++ b/content/en/apps/reference/nools-extras.md
@@ -1,0 +1,20 @@
+---
+title: "nools-extras.js"
+weight: 5
+description: >
+  **Nools Extras**: Helper variables and functions for Tasks and Targets
+relatedContent: >
+  apps/reference/targets
+  apps/reference/tasks
+---
+
+Helper variables and functions defined in `nools-extras.js` can be used by both [`tasks.js`]({{< ref "apps/reference/tasks.js" >}}) and [`targets.js`]({{< ref "apps/reference/targets.js" >}}).
+
+The following global variables can be used:
+
+| Variable | Description |
+|---|---|
+| `c.contact` | The contact's doc. All contacts have `type` of either `person` or `place`.
+| `c.reports` | An array of all the reports submitted about the contact.
+| `console` | Useful for outputting _debugging_ statements. Should not be used in production code. |
+| `Utils` | Useful functions across projects are available, and describe in the Utils section. |

--- a/content/en/apps/reference/targets.md
+++ b/content/en/apps/reference/targets.md
@@ -45,7 +45,7 @@ All targets are defined in the `targets.js` file as an array of objects accordin
 | `visible` | `boolean` | Whether the target is visible in the targets page. **Default: true** | no | 
 | `aggregate` | `boolean` | As of 3.9, defines whether the target will be displayed on the TargetAggregates page | no |
 
-{{< readfile file="apps/reference/_partial_functions.md" markdown="true" >}}
+{{< read-content file="apps/reference/_partial_functions.md" >}}
 
 ## Code Samples
 

--- a/content/en/apps/reference/targets.md
+++ b/content/en/apps/reference/targets.md
@@ -45,7 +45,8 @@ All targets are defined in the `targets.js` file as an array of objects accordin
 | `visible` | `boolean` | Whether the target is visible in the targets page. **Default: true** | no | 
 | `aggregate` | `boolean` | As of 3.9, defines whether the target will be displayed on the TargetAggregates page | no |
 
-{{< read-content file="apps/reference/_partial_functions.md" >}}
+## Utils
+{{< read-content file="apps/reference/_partial_utils.md" >}}
 
 ## Code Samples
 

--- a/content/en/apps/reference/tasks.md
+++ b/content/en/apps/reference/tasks.md
@@ -44,7 +44,7 @@ Tasks are configured in the `tasks.js` file. This file is a JavaScript module wh
 | `priority.level` | `high` or `medium` | Tasks that are `high` will display a high risk icon with the task. Default: `medium`. | no |
 | `priority.label` | `translation key` | Text shown with the task associated to the risk level. | no | 
 
-{{< readfile file="apps/reference/_partial_functions.md" markdown="true" >}}
+{{< read-content file="apps/reference/_partial_functions.md" >}}
 
 ## Code samples
 

--- a/content/en/apps/reference/tasks.md
+++ b/content/en/apps/reference/tasks.md
@@ -44,7 +44,8 @@ Tasks are configured in the `tasks.js` file. This file is a JavaScript module wh
 | `priority.level` | `high` or `medium` | Tasks that are `high` will display a high risk icon with the task. Default: `medium`. | no |
 | `priority.label` | `translation key` | Text shown with the task associated to the risk level. | no | 
 
-{{< read-content file="apps/reference/_partial_functions.md" >}}
+## Utils
+{{< read-content file="apps/reference/_partial_utils.md" >}}
 
 ## Code samples
 

--- a/layouts/shortcodes/read-content.html
+++ b/layouts/shortcodes/read-content.html
@@ -1,0 +1,4 @@
+{{ $path := .Get "file" }}
+{{ with $.Site.GetPage $path }}
+{{ .Content | markdownify }}
+{{ end }}


### PR DESCRIPTION
For #232. Hides the menu item using frontmatter. In doing so we can't use the readfile shortcode/function anymore so added a new shortcode which reads the file content.

Duplication is avoided, but drawback is that the content of the partial file is not in the TOC on the right side -- but this is not a regression. If there is a method to avoid duplication and adds the content to the TOC we should consider it. We could consider making this content a true page, and refer to it via `see-also`. The reason this wasn't chosen so far was that is it nice to have this content inline. Open to other ideas though!