### PR TITLE
RapidPro documentation - Features page

### DIFF
--- a/content/en/apps/concepts/interoperability.md
+++ b/content/en/apps/concepts/interoperability.md
@@ -6,7 +6,7 @@ description: >
   Exchanging information between CHT Core and other systems
 keywords: interoperability integrations
 relatedContent: >
-  apps/guides/integrations
+  apps/features/integrations
 ---
 
 *Interoperability* and *Integration* are often used interchangeably but mean different things. [This article](https://www.linkedin.com/pulse/lets-talk-interoperability-vs-integration-mike-fleck) offers a useful delineation between the two.

--- a/content/en/apps/features/integrations/_index.md
+++ b/content/en/apps/features/integrations/_index.md
@@ -4,4 +4,6 @@ weight: 10
 description: >
   Exchange data with other systems
 keywords: integrations interoperability
+relatedContent: >
+  apps/guides/integrations
 ---

--- a/content/en/apps/features/integrations/rapidpro.md
+++ b/content/en/apps/features/integrations/rapidpro.md
@@ -1,9 +1,32 @@
 ---
 title: "RapidPro"
-weight: 2
+weight: 3
 description: >
-   Trigger messaging flows and store the responses in CHT Core
+   Integrate interactive messaging conversations into your workflows
 keywords: rapidpro
 ---
+
+[RapidPro](https://rapidpro.io/) is a software product that allows you to visually build logic to support interactive messaging flows. The flows support a variety of technologies such as: SMS, USSD, IVR, Telegram, Facebook Messenger, and WhatsApp. RapidPro is open source and provides an [API](https://community.rapidpro.io/rapidpros-api/) to integrate with other applications. To learn more about the platform, check out RapidPro on [GitHub](https://rapidpro.github.io/rapidpro/), their [Community](https://community.rapidpro.io/) website, or join their Google [Group](https://groups.google.com/g/rapidpro). 
+
+## Overview
+CHT-based [SMS workflows]({{< ref "apps/concepts/workflows#sms-messaging" >}}) can be configured to support registering of new patients or pregnancies, recording outcomes of visits, confirmation via auto-responses, and scheduling reminders. Some projects are designed entirely around SMS workflows. The CHT also supports person to person SMS [messaging]({{< ref "apps/features/messaging" >}}) from the Messages tab. 
+
+For more complex messaging workflows or to utilize other messaging platforms, you can design workflows that leverage the functionality of RapidPro and the CHT together. This enables semi-automated, direct to patient approaches to health assessments and care coordination at the community level.
+
+## Workflows
+Integrated RapidPro/CHT workflows are very flexible and leverage the full functionality of each application; You configure RapidPro directly in RapidPro, and configure the CHT in the CHT and the two systems communicate with each other through APIs and [Outbound push]({{< ref "apps/reference/app-settings/outbound" >}}). With this architecture, you are not limited to a subset of functionality within either application.
+
+A simple RapidPro/CHT integration might include triggering an interactive SMS messaging flow in RapidPro whenever a new patient is registered in the CHT and then storing the responses of that messaging flow in the CHT. You could then conditionally trigger a [Task]({{< ref "apps/features/tasks" >}}) for a health worker in the CHT based on the patient responses from the RapidPro flow. 
+
+App builders have built and deployed a number of interactive messaging workflows that integrate RapidPro and the CHT already, see below for a few examples.
+
+### Contact Tracing
+The [COVID-19 Contact Tracing app]({{< ref "apps/examples/contact-tracing#workflow-example" >}}) uses RapidPro to send messages to quarantined COVID-19 patients. Messages are sent to the patients daily asking whether or not they developed new symptoms.  If so, a health worker will be notified by SMS and receive a CHT task. All responses to the RapidPro workflow are recorded in the CHT and can be queried in analytics.
+
+### Remote Training
+The [Remote Training by SMS app]({{< ref "apps/examples/training#remote-training-by-sms" >}}) uses RapidPro to train health workers on Antenatal Care in the language of their choice. If the health worker answers a training question incorrectly, a task can be created for their supervisor to follow up with them.
+
+### CHW Symptom and Mental Health Checks
+The [CHW Symptom and Mental Health Checks app](https://docs.google.com/document/d/19F6vOCNFKQnSyREiaBnryUmre20s5QZzYe0hWuWn-0k/edit) is used to proactively check in with health workers to screen for COVID-19 symptoms and/or the need for psychosocial counseling.
 
 


### PR DESCRIPTION
- updated related content on interoperability page to point to features instead of guides
- added some related content on the integrations index page
- added the top level RapidPro "features" page. This works as a standalone page. I'll create another branch/PR when I build out the "guide" section