### PR TITLE
fix see-also for hydration documentation

### DIFF
--- a/content/en/core/overview/db-schema.md
+++ b/content/en/core/overview/db-schema.md
@@ -95,7 +95,7 @@ Generally when contacts are **used** in the app they are first "hydrated", with 
 }
 ```
 
-{{% see-also page="apps/guides/data/hydration" title="Document hydration" %}}
+{{< see-also page="apps/guides/data/hydration" title="Document hydration" >}}
 
 As of version **3.10**, you can connect contacts with other documents via the `linked_docs` property. This allows the app to have access to these linked documents when the contact is used.
 


### PR DESCRIPTION
Not rendering properly due to see-also still using `%` instead of `<`

https://docs.communityhealthtoolkit.org/contribute/docs/style-guide/#cross-referencing-content