### PR TITLE
fail on bad builds in CI earlier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
           hugo-version: "0.71.1"
           extended: true
 
+      # Run "build" to catch errors as early as possible in CI
+      - name: All Branches - Build Hugo
+        run: hugo
+
       # Pinning to current version as of Aug 3, 2020 for stability
       - name: All Branches - Install Go v1.14
         uses: actions/setup-go@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
           extended: true
 
       - name: All Branches - Install npm modules for Hugo
-        if: ${{github.ref == 'refs/heads/master' }}
         run: |
           npm install
           npm install -g postcss-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,15 @@ jobs:
           hugo-version: "0.71.1"
           extended: true
 
+      - name: All Branches - Install npm modules for Hugo
+        if: ${{github.ref == 'refs/heads/master' }}
+        run: |
+          npm install
+          npm install -g postcss-cli
+          npm i -D autoprefixer
+
       # Run "build" to catch errors as early as possible in CI
-      - name: All Branches - Build Hugo
+      - name: All Branches - Test For Broken Builds in Hugo
         run: hugo
 
       # Pinning to current version as of Aug 3, 2020 for stability
@@ -57,13 +64,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-
-      - name: Master Branch Only - Install npm modules for hugo build
-        if: ${{github.ref == 'refs/heads/master' }}
-        run: |
-          npm install
-          npm install -g postcss-cli
-          npm i -D autoprefixer
 
       - name: Master Branch Only - Build for prod with minify
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
           hugo-version: "0.71.1"
           extended: true
 
+      - name: All Branches - Install Node 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
       - name: All Branches - Install npm modules for Hugo
         run: |
           npm install
@@ -57,12 +62,6 @@ jobs:
       - name: All Branches - Run Muffet link checker
         shell: bash
         run: ./.github/scripts/muffet.sh
-
-      - name: Master Branch Only - Install Node 12.x
-        if: ${{ github.ref == 'refs/heads/master' }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
 
       - name: Master Branch Only - Build for prod with minify
         if: github.ref == 'refs/heads/master'

--- a/content/en/apps/concepts/users.md
+++ b/content/en/apps/concepts/users.md
@@ -8,7 +8,7 @@ relatedContent: >
   design/personas
   apps/tutorials/contact-and-users-1
   apps/tutorials/contact-and-users-2
-  core/guides/users-bulk-load
+  core/guides/users-bulk-loadddd
 ---
 
 Apps built with the Core Framework use roles and permissions to determine who has access to what data. User roles are general categories you can use to assign a collection of broad permissions to users. There are two classes of roles: online and offline. Generally speaking, CHWs are usually offline users, while managers and nurses are usually online users. SMS users do not use the app, and thus do not have a user role.
@@ -24,7 +24,9 @@ Differing levels of access and permissions are assigned to each persona. A user 
 | CHWs            | Logs in at CHW Area level                      | Phone     | Users at this level have online and offline access to view households and family members, submit reports about them, and view tasks and targets about them.                                                                                                         |
 | Family members  | Registered at Household level, does not log in | Messaging | Family members might include fathers, mothers, children, and other adults. The program model determines which family members should be registered in the app. However, they are not users of the app, and do not log in themselves.                      |
 
-{{< see-also page="apps/reference/app-settings/user-roles" anchor="" title="Defining User Roles" >}}
+{{< see-also page="apps/reference/app-settings/user-roles/" anchor="" title="Defining User Roles" >}}
+
+[foo]({{< relref "barfdsfs/bash" >}})
 
 ### Online Users
 

--- a/content/en/apps/concepts/users.md
+++ b/content/en/apps/concepts/users.md
@@ -8,7 +8,7 @@ relatedContent: >
   design/personas
   apps/tutorials/contact-and-users-1
   apps/tutorials/contact-and-users-2
-  core/guides/users-bulk-loadddd
+  core/guides/users-bulk-load
 ---
 
 Apps built with the Core Framework use roles and permissions to determine who has access to what data. User roles are general categories you can use to assign a collection of broad permissions to users. There are two classes of roles: online and offline. Generally speaking, CHWs are usually offline users, while managers and nurses are usually online users. SMS users do not use the app, and thus do not have a user role.
@@ -24,9 +24,7 @@ Differing levels of access and permissions are assigned to each persona. A user 
 | CHWs            | Logs in at CHW Area level                      | Phone     | Users at this level have online and offline access to view households and family members, submit reports about them, and view tasks and targets about them.                                                                                                         |
 | Family members  | Registered at Household level, does not log in | Messaging | Family members might include fathers, mothers, children, and other adults. The program model determines which family members should be registered in the app. However, they are not users of the app, and do not log in themselves.                      |
 
-{{< see-also page="apps/reference/app-settings/user-roles/" anchor="" title="Defining User Roles" >}}
-
-[foo]({{< relref "barfdsfs/bash" >}})
+{{< see-also page="apps/reference/app-settings/user-roles" anchor="" title="Defining User Roles" >}}
 
 ### Online Users
 


### PR DESCRIPTION
This build adds a call to `hugo build` that exposes bad builds earlier on in the CI process.  We had [an issue where](https://github.com/medic/cht-docs/pull/298#issuecomment-685180595) a broken build was pushed and CI broke at the `All Branches - Run Muffet link checker` stop in a very non obvious way with:

```
dial tcp4 127.0.0.1:1313: connect: connection r#299 ed
##[error]Process completed with exit code 1.
```

This PR fixes that by explicitly running `hugo` early the CI process and it's called "All Branches - Test For Broken Builds in Hugo" so editors will know why their branch isn't passing CI when it breaks.

see #299