### PR TITLE
Fix CI postcss error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,19 +28,13 @@ jobs:
           hugo-version: "0.71.1"
           extended: true
 
-      # Run "build" to catch errors as early as possible in CI
-      - name: All Branches - Show Hugo verison
-        run: hugo version
-
       - name: All Branches - Install Node 12.x
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
 
       - name: All Branches - Install npm modules for Hugo
-        run: |
-          npm install
-          npm install -g postcss postcss-cli autoprefixer
+        run: npm install
 
       # Run "build" to catch errors as early as possible in CI
       - name: All Branches - Test For Broken Builds in Hugo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,9 @@ jobs:
       - name: All Branches - Install npm modules for Hugo
         run: |
           npm install
+          npm install -g postcss
           npm install -g postcss-cli
-          npm i -D autoprefixer
+          npm install -g autoprefixer
 
       # Run "build" to catch errors as early as possible in CI
       - name: All Branches - Test For Broken Builds in Hugo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
           hugo-version: "0.71.1"
           extended: true
 
+      # Run "build" to catch errors as early as possible in CI
+      - name: All Branches - Show Hugo verison
+        run: hugo version
+
       - name: All Branches - Install Node 12.x
         uses: actions/setup-node@v1
         with:
@@ -36,9 +40,7 @@ jobs:
       - name: All Branches - Install npm modules for Hugo
         run: |
           npm install
-          npm install -g postcss
-          npm install -g postcss-cli
-          npm install -g autoprefixer
+          npm install -g postcss postcss-cli autoprefixer
 
       # Run "build" to catch errors as early as possible in CI
       - name: All Branches - Test For Broken Builds in Hugo

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cht-docs",
+  "version": "1.0.0",
+  "dependencies": {
+    "postcss-cli": "7.1.2",
+    "autoprefixer": "9.8.6"
+  }
+}


### PR DESCRIPTION
I'm gonna make a tshirt "@newtewt is my hero" (but let's hope it doesn't [infect all of GH](https://en.wikipedia.org/wiki/Samy_%28computer_worm%29) ;). With newtewt's help, he verified my initial hunch of `autoprefixer` versions upgrading out from under us was indeed the problem.  

Fix was to add a `package.json` and pin the versions. I went ahead pinned both `autoprefixer` and `postcss-cli`.

see  #313

@abbyad  or @nomulex - I don't think we need ya both to do a review.  First come, first served?  I'm easy. 

PR is ready for ya!