### PR TITLE
remove unused Use Kitematic subtitle

### DIFF
--- a/content/en/core/guides/docker-setup.md
+++ b/content/en/core/guides/docker-setup.md
@@ -90,10 +90,6 @@ Clean data volume:
 
 After following the above three commands, you can re-run `docker-compose up` and create a fresh install (no previous data present)
 
-## Use Kitematic (GUI for Docker tools)
-
-
-
 ## Port Conflicts
 
 In case you are already running services on HTTP(80) and HTTPS(443), you will have to map new ports to the medic-os container.


### PR DESCRIPTION
there was a subtitle on the [docker page](https://docs.communityhealthtoolkit.org/core/guides/docker-setup/#use-kitematic-gui-for-docker-tools) that had no content.  we should remove it until we have content for it!