### PR TITLE
Typo in ANC Icons Best Practices

### DIFF
--- a/content/en/design/best-practices/_index.md
+++ b/content/en/design/best-practices/_index.md
@@ -121,7 +121,7 @@ The Community Health Toolkit includes a collection of [60+ free icons]({{< ref "
 
 | Icon 	| ANC                                         	|
 |------	|:-----------------------------------------------	|
-| ![ANC](../icons/forms_tasks_targets/SVGs/icon-people-woman-pregnant.svg) | - ANC Registration<br>- ANC Visit or Missed Visit<br>- ANCE Follow-Up 	|
+| ![ANC](../icons/forms_tasks_targets/SVGs/icon-people-woman-pregnant.svg) | - ANC Registration<br>- ANC Visit or Missed Visit<br>- ANC Follow-Up 	|
 | ![ANC Danger](../icons/forms_tasks_targets/SVGs/icon-ANC-danger-sign.svg) | - ANC Danger Sign<br>- ANC Danger Sign Follow-Up|
 
 


### PR DESCRIPTION
Updated typo under https://docs.communityhealthtoolkit.org/design/best-practices/#icons  

It said:

- ANCE Follow-Up

I changed it to

- ANC Follow-Up