### PR TITLE
Rename generic integrations to be custom integrations

### DIFF
--- a/content/en/apps/features/integrations/custom.md
+++ b/content/en/apps/features/integrations/custom.md
@@ -1,16 +1,18 @@
 ---
-title: "Generic"
+title: "Custom"
 weight: 1
 description: >
    Integrate with any system using RESTful APIs
-keywords: generic
+keywords: generic, custom, integrations
+aliases:
+    -    /apps/features/integrations/generic/
 relatedContent: >
   apps/features/integrations/dhis2
   apps/features/integrations/rapidpro
   apps/features/integrations/openmrs
 ---
 
-The CHT Core Framework includes functionality that allows sharing data with any API-based system. App Builders have configured CHT integrations with OpenMRS, KenyaEMR, Bahmni, DHIS2, RapidPro, Apache NiFi, OpenHIM, custom EMRs, and several other systems.  
+The CHT Core Framework includes functionality that allows sharing data with any API-based system. Developers have configured CHT integrations with OpenMRS, KenyaEMR, Bahmni, DHIS2, RapidPro, Apache NiFi, OpenHIM, custom electronic medical records (EMR), and several other systems.  
 
 ## Overview
 
@@ -29,7 +31,7 @@ As you design your use cases, creating a [sequence diagram](https://www.webseque
 
 ## Integration Design Patterns
 
-Broadly speaking, there are a number of different interactions that may occur between digital health systems. Below are some high level design patterns you'll likely encounter:
+There are a number of different interactions that may occur between digital health systems. Below are some common use cases:
 
 1. Creating a patient in the CHT creates that patient in another system
 2. Creating a patient in another system creates that patient in the CHT
@@ -41,7 +43,7 @@ Broadly speaking, there are a number of different interactions that may occur be
 
 ## Sending data to other systems 
 
-Using the [outbound]({{< ref "apps/reference/app-settings/outbound" >}}) feature, you can configure the CHT to send data to another system. Before starting, you'll want to make sure you understand the APIs of the destination system and have login credentials with adequate privileges. 
+Using the [outbound push]({{< ref "apps/reference/app-settings/outbound" >}}) feature, you can configure the CHT to send data to another system. Before starting, you'll want to make sure you understand the APIs of the destination system and have login credentials with adequate privileges. 
 
 To send data to other systems from the CHT, you will need to do the following:
 

--- a/content/en/apps/features/integrations/openmrs.md
+++ b/content/en/apps/features/integrations/openmrs.md
@@ -5,11 +5,11 @@ description: >
    Exchange patient-level data with systems based on the OpenMRS platform
 keywords: openmrs
 relatedContent: >
-  apps/features/integrations/generic
+  apps/features/integrations/custom
   apps/features/integrations/rapidpro
   apps/features/integrations/dhis2
 ---
 
 [OpenMRS](https://openmrs.org) is an open source electronic medical record system used in dozens of countries. Integrating CHT apps with OpenMRS can open up opportunities to improve health outcomes for patients by promoting better coordination of care. For example, referrals by CHWs in the community can be sent electronically to health facilities using OpenMRS so that nurses and clinicians can prepare for their visit and have full access to the assessment done by a CHW.
 
-Integrating CHT apps with OpenMRS can be achieved using the [OpenMRS REST API](https://rest.openmrs.org/) and following the guidance in the [Generic Integrations]({{< ref "apps/features/integrations/generic" >}}) documentation. 
+Integrating CHT apps with OpenMRS can be achieved using the [OpenMRS REST API](https://rest.openmrs.org/) and following the guidance in the [Custom Integrations]({{< ref "apps/features/integrations/custom" >}}) documentation. 


### PR DESCRIPTION
As per #429

This may be our first use of aliases... @mrjones-plip is this the best way to do redirects when changing the file name? 

Also, should the best practice be to change all references too (one of one done in this PR)?