### PR TITLE
fix group_assessment variable access

### DIFF
--- a/content/en/apps/tutorials/tasks.md
+++ b/content/en/apps/tutorials/tasks.md
@@ -60,7 +60,7 @@ Create the task as per the detail above.
     appliesTo: 'reports',
     appliesToType: ['assessment'],
     appliesIf: function(contact, report) {
-      return report && report.fields.group_assessment && parseInt(report.fields.group_assessment)  > 3;
+      return report && report.fields.group_assessment && parseInt(report.fields.group_assessment.cough_duration) > 3;
     },
     actions: [
       {


### PR DESCRIPTION
`parseInt(report.fields.group_assessment) > 3;` returns NaN and the task never appears. What we're actually after is `report.fields.group_assessment.cough_duration`. Fixes #433 