### PR TITLE
Remove unused FAQ section

### DIFF
--- a/content/en/core/faq/_index.md
+++ b/content/en/core/faq/_index.md
@@ -1,8 +1,0 @@
----
-title: Frequently Asked Questions
-linkTitle: "FAQ"
-weight: 5
-description: >
-  Curated answers to common questions when developing with CHT Core
----
-


### PR DESCRIPTION
Ever since launch of the docs site, we've had [this FAQ section](docs.communityhealthtoolkit.org/core/faq/) that is empty.  I think since it's because it's still empty and not being used, we should remove it!