### PR TITLE
6741 - Adding device info to about page 

### DIFF
--- a/content/en/apps/guides/performance/telemetry.md
+++ b/content/en/apps/guides/performance/telemetry.md
@@ -98,7 +98,9 @@ When the aggregate doc is created the Telemetry service also includes a snapshot
 | `hardwareConcurrency` | The number of cores reported from the browser. Added in 3.4.0. |
 | `screen.width` | The width of the screen in pixels. Added in 3.4.0. |
 | `screen.height` | The height of the screen in pixels. Added in 3.4.0. |
-| `deviceInfo.app.version` | The version of the Android app. Only captured when running in the Android wrapper v0.4.0+. Added in 3.8.0. |
+| `deviceInfo.app.version` | The version name of the Android app. Only captured when running in the Android wrapper v0.4.0+. Added in 3.8.0. |
+| `deviceInfo.app.packageName` | The package name of the Android app. Only captured when running in the Android wrapper v0.9.0+. Added in 3.12.0. |
+| `deviceInfo.app.versionCode` | The Internal [version code](https://developer.android.com/reference/android/R.styleable#AndroidManifest_versionCode) of the Android app. Only captured when running in the Android wrapper v0.9.0+. Added in 3.12.0. |
 | `deviceInfo.software.androidVersion` | The version of Android OS. Only captured when running in the Android wrapper v0.4.0+. Added in 3.8.0. |
 | `deviceInfo.software.osApiLevel` | The API of the Android OS. Only captured when running in the Android wrapper v0.4.0+. Added in 3.8.0. |
 | `deviceInfo.software.osVersion` | The version of Android OS (detailed). Only captured when running in the Android wrapper v0.4.0+. Added in 3.8.0. |


### PR DESCRIPTION
# Description

Adding documentation about the new properties in telemetry: packageName and versionCode.

CHT-Core: https://github.com/medic/cht-core/pull/7131
CHT-Android: https://github.com/medic/cht-android/pull/182

https://github.com/medic/cht-core/issues/6741

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.