### PR TITLE
Document how app developers can use docker compose

### DIFF
--- a/content/en/apps/guides/hosting/_index.md
+++ b/content/en/apps/guides/hosting/_index.md
@@ -4,3 +4,9 @@ weight: 100
 description: >
  Guides for hosting, maintaining, and monitoring CHT applications
 ---
+
+Before beggining any of these guide, be sure to meet all of the [CHT hosting requirements]({{< relref "apps/guides/hosting/requirements" >}}) first.
+
+To host a production instance of the CHT, use either the [AWS]({{< relref "apps/guides/hosting/ec2-setup-guide" >}}) or [Self]({{< relref "apps/guides/hosting/self-hosting" >}}) hosting guides. To do app development, see our [App Developer]({{< relref "apps/guides/hosting/app-developer" >}}) hosting guide.
+
+To get an overview on how these hosting solutions use `docker` and `docker-compose`, be sure to read the [guide on a local CHT setup]({{< relref "apps/tutorials/local-setup" >}}).

--- a/content/en/apps/guides/hosting/_index.md
+++ b/content/en/apps/guides/hosting/_index.md
@@ -5,8 +5,8 @@ description: >
  Guides for hosting, maintaining, and monitoring CHT applications
 ---
 
-Before beggining any of these guide, be sure to meet all of the [CHT hosting requirements]({{< relref "apps/guides/hosting/requirements" >}}) first.
+{{% alert title="Note" %}} To get an overview on how these hosting solutions use `docker` and `docker-compose`, as well as other key CHT concepts, be sure to read the [guide on a Local Setup]({{< relref "apps/tutorials/local-setup" >}}). {{% /alert %}}
+
+Before beggining any of these guides, be sure to meet all of the [CHT hosting requirements]({{< relref "apps/guides/hosting/requirements" >}}) first.
 
 To host a production instance of the CHT, use either the [AWS]({{< relref "apps/guides/hosting/ec2-setup-guide" >}}) or [Self]({{< relref "apps/guides/hosting/self-hosting" >}}) hosting guides. To do app development, see our [App Developer]({{< relref "apps/guides/hosting/app-developer" >}}) hosting guide.
-
-To get an overview on how these hosting solutions use `docker` and `docker-compose`, be sure to read the [guide on a local CHT setup]({{< relref "apps/tutorials/local-setup" >}}).

--- a/content/en/apps/guides/hosting/app-developer.md
+++ b/content/en/apps/guides/hosting/app-developer.md
@@ -1,0 +1,9 @@
+---
+title: "App Developer Hosting"
+linkTitle: "App Developer Hosting"
+weight: 
+description: >
+  Hosting the CHT when developing apps
+---
+
+## TBD

--- a/content/en/apps/guides/hosting/app-developer.md
+++ b/content/en/apps/guides/hosting/app-developer.md
@@ -49,7 +49,7 @@ The second instance is now accessible at  [https://localhost:8443](https://local
 
 ## The `.env` file 
 
-Often times it's convenient to use revision control, like GitHub, to store and publish changes in a CHT app.  A nice compliment to this is store the specifics on how to run the `docker-compose` command for each app. By using a shared `docker-compose` configuration for all developers on the same app, it avoids any port collisions and enables all developers to have a unified configuration.
+Often times it's convenient to use revision control, like GitHub, to store and publish changes in a CHT app.  A nice compliment to this is to store the specifics on how to run the `docker-compose` command for each app. By using a shared `docker-compose` configuration for all developers on the same app, it avoids any port collisions and enables all developers to have a unified configuration.
 
 Using the above `the_second` sample project, we can create another directory to host this project's configuration:
 

--- a/content/en/apps/guides/hosting/app-developer.md
+++ b/content/en/apps/guides/hosting/app-developer.md
@@ -13,21 +13,23 @@ To deploy the CHT in production, see either [AWS hosting]({{< relref "apps/guide
 
 ## Getting started
 
-Be sure to meet the [CHT hosting requirements]({{< relref "apps/guides/hosting/requirements" >}}) first. As well, if any other `medic-os` instances using [the main `docker-compose.yml` file](https://github.com/medic/cht-core/blob/master/docker-compose.yml) are running locally, stop them. Otherwise port, storage volume and container name conflicts may occur.
+Be sure to meet the [CHT hosting requirements]({{< relref "apps/guides/hosting/requirements" >}}) first. As well, if any other `medic-os` instances using [the main `docker-compose.yml` file](https://github.com/medic/cht-core/blob/master/docker-compose.yml) are running locally, stop them otherwise port, storage volume and container name conflicts may occur.
 
-After meeting these requirements, download the two developer YAML files in the directory you want to store them:
+After meeting these requirements, download the developer YAML file in the directory you want to store them:
 
 ```shell script
 curl -o docker-compose-developer.yml https://raw.githubusercontent.com/medic/cht-core/master/docker-compose-developer-base.yml
 ```
 
-To start the first developer CHT instance, run `docker-compose` and specify the two files that were just download:
+To start the first developer CHT instance, run `docker-compose` and specify the file that was just download:
 
 ```shell script
 docker-compose -f docker-compose-developer.yml up
 ```
 
-This script may take some minutes to fully start depending on the speed of the Internet connection speed of the bare metal host.  After it has completed, the CHT should be accessible on [https://localhost](https://localhost).
+This may take some minutes to fully start depending on the speed of the Internet connection and speed of the bare-metal host.  After it has completed, the CHT should be accessible on [https://localhost](https://localhost).
+
+When connecting to a new dev CHT instance for the first time, an error will be shown, "Your connection is not private" (see [screenshot](/apps/tutorials/local-setup/privacy.error.png)). To get past this, click "Advanced" and then click "Proceed to localhost".
 
 ## Running the Nth CHT instance
 
@@ -47,12 +49,47 @@ The second instance is now accessible at  [https://localhost:8443](https://local
 
 ## The `.env` file 
 
-TBD WIP
+Often times it's convenient to use revision control, like GitHub, to store and publish changes in a CHT app.  A nice compliment to this is store the specifics on how to run the `docker-compose` command for each app. By using a shared `docker-compose` configuration for all developers on the same app, it avoids any port collisions and enables all developers to have a unified configuration.
 
-## Switching between projects
+Using the above `the_second` sample project, we can create another directory to host this project's configuration:
 
-TBD WIP
+```shell
+mkdir ../the_second
+```
+
+Create a file `../the_second/.env-docker-compose` with this contents:
+
+```shell
+COMPOSE_PROJECT_NAME=the_second
+CHT_HTTP=8081
+CHT_HTTPS=8443
+```
+
+Now it's easy to boot this environment by specifying which `.env` file to use:
+
+```shell
+docker-compose --env-file ../the_second/.env-docker-compose -f docker-compose-developer.yml up
+```
+
+## Switching & concurrent projects
+
+The easiest way to switch between projects is to stop the first set of containers and start the second set. Cancel the first project running in the foreground with `ctrl + c`. Then start the second project using either the `.env` file or use the explicit command with ports and project name as shown above.
+
+To run projects concurrently, instead of cancelling the first one, open a second terminal and start the second project.  
+
+To read more about how `docker-compose` works, be sure to read the [helpful docker-compose commands]({{< relref "core/guides/docker-setup#helpful-docker-commands" >}}) page. 
 
 ## Cookie collisions
 
-TBD WIP but cover 127.0.0.1 vs 127.0.1.1 , or change examples above and explain why?
+The CHT stores its cookies based on the domain.  This means if you're running two concurrent instances on `https://localhost` and `https://localhost:8443`, the CHT would store the cookie under the same `localhost` domain. When logging out of one instance, you would get logged out of both and other consistencies.
+
+To avoid this collision of cookies, you can use different IP addresses to access the instances.  This works because the IPs that are available to reference `localhost` are actually a `/8` netmask, meaning [there are 16 million addresses](https://en.wikipedia.org/wiki/Localhost#Name_resolution) to choose from!  
+
+Using the above two configurations, these URLs could work to avoid the cookie colission: 
+
+* [https://127.0.0.1](https://127.0.0.1)
+* [https://127.0.0.2:8443](https://127.0.0.2:8443)
+
+This would result in the domains being `127.0.0.1` and `127.0.0.2` from the CHT's perspective.
+
+Another work around is to use incognito mode, [browser containers](https://support.mozilla.org/en-US/kb/containers) or different browsers.

--- a/content/en/apps/guides/hosting/app-developer.md
+++ b/content/en/apps/guides/hosting/app-developer.md
@@ -18,7 +18,7 @@ Be sure to meet the [CHT hosting requirements]({{< relref "apps/guides/hosting/r
 After meeting these requirements, download the developer YAML file in the directory you want to store them:
 
 ```shell script
-curl -o docker-compose-developer.yml https://raw.githubusercontent.com/medic/cht-core/master/docker-compose-developer-base.yml
+curl -o docker-compose-developer.yml https://raw.githubusercontent.com/medic/cht-core/master/docker-compose-developer.yml
 ```
 
 To start the first developer CHT instance, run `docker-compose` and specify the file that was just download:

--- a/content/en/apps/guides/hosting/app-developer.md
+++ b/content/en/apps/guides/hosting/app-developer.md
@@ -18,14 +18,13 @@ Be sure to meet the [CHT hosting requirements]({{< relref "apps/guides/hosting/r
 After meeting these requirements, download the two developer YAML files in the directory you want to store them:
 
 ```shell script
-curl -o docker-compose-developer-base.yml https://raw.githubusercontent.com/medic/cht-core/master/docker-compose-developer-base.yml
-curl -o docker-compose-developer-storage.yml https://raw.githubusercontent.com/medic/cht-core/master/docker-compose.yml
+curl -o docker-compose-developer.yml https://raw.githubusercontent.com/medic/cht-core/master/docker-compose-developer-base.yml
 ```
 
 To start the first developer CHT instance, run `docker-compose` and specify the two files that were just download:
 
 ```shell script
-docker-compose -f docker-compose-developer-base.yml -f docker-compose-developer-storage.yml up
+docker-compose -f docker-compose-developer.yml up
 ```
 
 This script may take some minutes to fully start depending on the speed of the Internet connection speed of the bare metal host.  After it has completed, the CHT should be accessible on [https://localhost](https://localhost).
@@ -34,21 +33,14 @@ This script may take some minutes to fully start depending on the speed of the I
 
 After running the first instance of the CHT, it's easy to run as many more as are needed.  This is achieved by specifying different:
 
-* ports for `HTTP` and `HTTPS` traffic (`CHT_HTTP` and `CHT_HTTPS`)
-* storage volume to keep all the CHT data (`CHT_DATA`)
+* port for `HTTP` redirects (`CHT_HTTP`)
+* port for `HTTPS` traffic (`CHT_HTTPS`)
 * project to for the docker compose call (`-p PROJECT`)
 
-Assuming you want to start a new project called `the_second`, copy the volume YAML file to a new one then replace the volume name inside it with sed:
+Assuming you want to start a new project called `the_second` and  start the instance on `HTTP` port `8081` and `HTTPS` port `8443`, this would be the command:
 
 ```shell script
-cp docker-compose-developer-storage.yml docker-compose-developer-the_second-storage.yml`
-sed -e 's/medic-data/the_second/' -i docker-compose-developer-the_second-storage.yml
-```
-
-Now start the instance on `CHT_HTTP` and `CHT_HTTPS` ports, a new project, and  the same `CHT_DATA` volume name used in the `sed` command above:
-
-```shell
-CHT_DATA=the_second CHT_HTTP=8081 CHT_HTTPS=8443 docker-compose -p the_second -f docker-compose-developer-base.yml -f docker-compose-developer-the_second-storage.yml up
+CHT_HTTP=8081 CHT_HTTPS=8443 docker-compose -p the_second -f docker-compose-developer.yml up
 ```
 
 The second instance is now accessible at  [https://localhost:8443](https://localhost:8443).

--- a/content/en/apps/guides/hosting/app-developer.md
+++ b/content/en/apps/guides/hosting/app-developer.md
@@ -91,5 +91,3 @@ Using the above two configurations, these URLs could work to avoid the cookie co
 * [https://127.0.0.2:8443](https://127.0.0.2:8443)
 
 This would result in the domains being `127.0.0.1` and `127.0.0.2` from the CHT's perspective.
-
-Another work around is to use incognito mode, [browser containers](https://support.mozilla.org/en-US/kb/containers) or different browsers.

--- a/content/en/apps/guides/hosting/app-developer.md
+++ b/content/en/apps/guides/hosting/app-developer.md
@@ -1,9 +1,11 @@
 ---
 title: "App Developer Hosting"
 linkTitle: "App Developer Hosting"
-weight: 
+weight: 40
 description: >
   Hosting the CHT when developing apps
 ---
 
-## TBD
+## Assumptions
+
+This guide assumes you are developer wanting to run multiple instances of the CHT

--- a/content/en/apps/guides/hosting/app-developer.md
+++ b/content/en/apps/guides/hosting/app-developer.md
@@ -6,6 +6,59 @@ description: >
   Hosting the CHT when developing apps
 ---
 
-## Assumptions
+{{% alert title="Note" %}} This guide assumes you are a CHT app developer wanting to either run concurrent instances of the CHT, or easily be able to switch between different instances without loosing any data while doing so. To do development on the CHT core itself, see the [development guide](https://github.com/medic/cht-core/blob/master/DEVELOPMENT.md).{{% /alert %}}
 
-This guide assumes you are developer wanting to run multiple instances of the CHT
+
+## Getting started
+
+Be sure to meet the [CHT hosting requirements]({{< relref "apps/guides/hosting/requirements" >}}) first. As well, if any other `medic-os` instances using [the main `docker-compose.yml` file](https://github.com/medic/cht-core/blob/master/docker-compose.yml) are running locally, stop them. Otherwise port, storage volume and container name conflicts may occur.
+
+After meeting these requirements, download the two developer YAML files in the directory you want to store them:
+
+```shell script
+curl -o docker-compose-developer-base.yml https://raw.githubusercontent.com/medic/cht-core/master/docker-compose-developer-base.yml
+curl -o docker-compose-developer-storage.yml https://raw.githubusercontent.com/medic/cht-core/master/docker-compose.yml
+```
+
+To start the first developer CHT instance, run `docker-compose` and specify the two files that were just download:
+
+```shell script
+docker-compose -f docker-compose-developer-base.yml -f docker-compose-developer-storage.yml up
+```
+
+This script may take some minutes to fully start depending on the speed of the Internet connection speed of the bare metal host.  After it has completed, the CHT should be accessible on [https://localhost](https://localhost).
+
+## Running the Nth CHT instance
+
+After running the first instance of the CHT, it's easy to run as many more as are needed.  This is achieved by specifying different:
+
+* ports for `HTTP` and `HTTPS` traffic (`CHT_HTTP` and `CHT_HTTPS`)
+* storage volume to keep all the CHT data (`CHT_DATA`)
+* project to for the docker compose call (`-p PROJECT`)
+
+Assuming you want to start a new project called `the_second`, copy the volume YAML file to a new one then replace the volume name inside it with sed:
+
+```shell script
+cp docker-compose-developer-storage.yml docker-compose-developer-the_second-storage.yml`
+sed -e 's/medic-data/the_second/' -i docker-compose-developer-the_second-storage.yml
+```
+
+Now start the instance on `CHT_HTTP` and `CHT_HTTPS` ports, a new project, and  the same `CHT_DATA` volume name used in the `sed` command above:
+
+```shell
+CHT_DATA=the_second CHT_HTTP=8081 CHT_HTTPS=8443 docker-compose -p the_second -f docker-compose-developer-base.yml -f docker-compose-developer-the_second-storage.yml up
+```
+
+The second instance is now accessible at  [https://localhost:8443](https://localhost:8443).
+
+## The `.env` file 
+
+TBD WIP
+
+## Switching between projects
+
+TBD WIP
+
+## Cookie collisions
+
+TBD WIP but cover 127.0.0.1 vs 127.0.1.1 , or change examples above and explain why?

--- a/content/en/apps/guides/hosting/app-developer.md
+++ b/content/en/apps/guides/hosting/app-developer.md
@@ -6,7 +6,9 @@ description: >
   Hosting the CHT when developing apps
 ---
 
-{{% alert title="Note" %}} This guide assumes you are a CHT app developer wanting to either run concurrent instances of the CHT, or easily be able to switch between different instances without loosing any data while doing so. To do development on the CHT core itself, see the [development guide](https://github.com/medic/cht-core/blob/master/DEVELOPMENT.md).{{% /alert %}}
+{{% alert title="Note" %}} This guide assumes you are a CHT app developer wanting to either run concurrent instances of the CHT, or easily be able to switch between different instances without loosing any data while doing so. To do development on the CHT core itself, see the [development guide](https://github.com/medic/cht-core/blob/master/DEVELOPMENT.md). 
+
+To deploy the CHT in production, see either [AWS hosting]({{< relref "apps/guides/hosting/self-hosting.md" >}}) or [Self hosting]({{< relref "apps/guides/hosting/ec2-setup-guide.md" >}}){{% /alert %}}
 
 
 ## Getting started

--- a/content/en/apps/guides/hosting/app-developer.md
+++ b/content/en/apps/guides/hosting/app-developer.md
@@ -27,7 +27,7 @@ To start the first developer CHT instance, run `docker-compose` and specify the 
 docker-compose -f docker-compose-developer.yml up
 ```
 
-This may take some minutes to fully start depending on the speed of the Internet connection and speed of the bare-metal host.  After it has completed, the CHT should be accessible on [https://localhost](https://localhost).
+This may take some minutes to fully start depending on the speed of the Internet connection and speed of the bare-metal host. This is because docker needs to download all the storage layers for all the containers and the CHT needs to run the first run set up. After downloads and setup has completed, the CHT should be accessible on [https://localhost](https://localhost).
 
 When connecting to a new dev CHT instance for the first time, an error will be shown, "Your connection is not private" (see [screenshot](/apps/tutorials/local-setup/privacy.error.png)). To get past this, click "Advanced" and then click "Proceed to localhost".
 

--- a/content/en/core/guides/docker-setup.md
+++ b/content/en/core/guides/docker-setup.md
@@ -34,7 +34,7 @@ export DOCKER_COUCHDB_ADMIN_PASSWORD=<random_pw>
 
 Inside the directory that you saved the above `docker-compose.yml`, run:
 ```
-$ docker-compose -f docker-compose.yml up
+$ docker-compose up
 ```
 {{% alert title="Note" %}}
 In certain shells, docker-compose may not interpolate the admin password that was exported above. In that case, your admin user had a password automatically generated. Note the `New CouchDB Administrative User` and `New CouchDB Administrative Password` in the output terminal. You can retrieve these via running `docker logs medic-os` and searching the terminal.

--- a/content/en/core/guides/docker-setup.md
+++ b/content/en/core/guides/docker-setup.md
@@ -72,7 +72,7 @@ After following the above three commands, you can re-run `docker-compose up` and
 
 ## Port Conflicts
 
-In case you are already running services on HTTP(80) and HTTPS(443), you will have to map new ports to the medic-os container.
+In case you are already running services on HTTP(80) and HTTPS(443), you will have to map new ports to the `medic-os` container.
 
 Turn down and remove all existing containers that were started: 
 * `docker-compose down && docker-compose rm`
@@ -87,17 +87,11 @@ On Mac (10.10 and above):
 sudo lsof -iTCP -sTCP:LISTEN -n -P | grep ':<port>'
 ```
 You can either kill the service which is occupying HTTP/HTTPS ports, or run the container with forwarded ports that are free.
-In your compose file, change the ports under medic-os:
+Stop your containers and relaunch with different ports. Here it's shown launching them with ports `8080` and `8443`:
+
+
 ```
-services:
-  medic-os:
-    container_name: medic-os
-    image: medicmobile/medic-os:latest
-    volumes:
-      - medic-data:/srv
-    ports:
-     - 8080:80
-     - 444:443
+CHT_HTTP=8080 CHT_HTTPS=8443 docker-compose up
 ```
 {{% alert title="Note" %}}
 You can substitute 8080, 444 with whichever ports are free on your host. You would now visit https://localhost:444 to visit your project.
@@ -139,7 +133,7 @@ List running containers:
 * `sudo docker ps`
 
 List all available docker containers with their status
-* `sudo docker ps -a
+* `sudo docker ps -a`
 
 Stop container
 * `sudo docker stop <container_id>/<container_name>`


### PR DESCRIPTION
This PR:

* Adds a new page documenting how to use the new `docker-compose-developer.yml` file
* Makes minor updates/corrections to `core/guides/docker-setup` page
* Adds an intro section on the `apps/guides/hosting` page

per #medic/cht-core/issues/7211