### PR TITLE
timeout-minutes set to 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   BuildLinkCheckPushLive:
     name:
     runs-on: ubuntu-18.04
+    timeout-minutes: 15
     steps:
 
       - name: All Branches - Git checkout, including recursive call for Docsy theme


### PR DESCRIPTION
best practice is to always have an [upper bounds](https://github.com/marketplace/actions/enforce-timeout-minutes) for a GH action run time.  Looking at [existing actions](https://github.com/medic/cht-docs/actions), our average time is about a 1m5s, so 15 min should be plenty of extra room!