### PR TITLE
7260 - Add more granularity to startup telemetry

### DIFF
--- a/content/en/apps/guides/performance/telemetry.md
+++ b/content/en/apps/guides/performance/telemetry.md
@@ -39,7 +39,7 @@ The telemetry data gathered changes with different versions of the framework. Cu
 | `boot_time` | The overall boot time including loading the code, purging, and accessing the database. |
 | `boot_time:1:to_first_code_execution` | The time between the page loading and the JavaScript starting to run. |
 | `boot_time:2:to_bootstrap` | The time between JavaScript starting and the bootstrapping (purging, initial replication, etc) to complete. |
-| `boot_time:2_1:to_replication` | The time it takes to complete the replication. Added in 3.14. |
+| `boot_time:2_1:to_replication` | The time it took to complete initial replication. If initial replication was interrupted and retried, this value will be incorrect. Added in 3.14. |
 | `boot_time:2_2:to_purge` | The time it takes to complete the purge. Added in 3.14. |
 | `boot_time:2_3:to_purge_meta` | The time it takes to complete the purge of local meta database. Added in 3.14. |
 | `boot_time:3:to_angular_bootstrap` | The time between bootstrapping completing and the webapp being ready to use. |


### PR DESCRIPTION
# Description

This PR:
- Add documentation for new records in telemetry
  - boot_time:2_1:to_replication
  - boot_time:2_2:to_purge
  - boot_time:2_3:to_purge_meta
  - boot_time:purging:<boolean>
  - boot_time:purging_failed
  - boot_time:purging_meta:<boolean>
  - boot_time:purging_meta_failed
  - user_settings:language:[language code] (This one for ticket https://github.com/medic/cht-core/issues/7089)

Ticket: https://github.com/medic/cht-core/issues/7260
PR Core: https://github.com/medic/cht-core/pull/7364

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
