### PR TITLE
Update dependency documentation

### DIFF
--- a/content/en/core/guides/update-dependencies.md
+++ b/content/en/core/guides/update-dependencies.md
@@ -40,7 +40,7 @@ Then for each folder go through these steps.
 - Make sure the version of `webapp/jquery` is the same as `webapp/enketo-core/jquery`.
 - Make sure the version of `api/enketo-xslt` is the same as `webapp/enketo-core/enketo-transformer/enketo-xslt`.
 - Don't update `loadash/core` since 4.17.21 is failing, this is an [open issue](https://github.com/lodash/lodash/issues/4904) in their repository.
-- Don't update `helmet` since it is not supporting NodeJS 8 anymore. Their minimum is NodeJS 10+.
+- Don't update `helmet` since it is not supporting NodeJS 8 anymore. Its minimum is NodeJS 10+.
 - If you have trouble upgrading any other dependency and you think it'll be challenging to fix it then raise a new issue to upgrade just that dependency. Don't hold up all the other upgrades you've made.
 
 ## Troubleshooting


### PR DESCRIPTION
Now that we do not need to support development environments with Node <= 10, we can upgrade `karma-firefox-launcher`, `node-sass`, and `sinon` (and no longer need a warning for these dependencies).

`helmet` still cannot be upgraded since it is not a development dependency. 

Dependency uplift PR: https://github.com/medic/cht-core/pull/7371
Dependency uplift issue:  https://github.com/medic/cht-core/issues/7349