### PR TITLE
Fix a typo in `registrations`

### DIFF
--- a/content/en/apps/reference/app-settings/registrations.md
+++ b/content/en/apps/reference/app-settings/registrations.md
@@ -35,7 +35,7 @@ The `registrations` key contains actions that need to be performed for incoming 
 
 ## Code sample
 
-This sample shows how a schedule would be triggered by a `pregnancy` report if the `last_mentrual_period` value is set.  
+This sample shows how a schedule would be triggered by a `pregnancy` report if the `last_menstrual_period` value is set.  
 
 ```json
 


### PR DESCRIPTION
Corrected `mentrual` to `menstrual`