### PR TITLE
#511 Add calculation field in form example.

### DIFF
--- a/content/en/apps/tutorials/tasks.md
+++ b/content/en/apps/tutorials/tasks.md
@@ -90,8 +90,13 @@ Create the task as per the detail above.
 
 ##### Data fields
 
+
 | type                          | name              | label                              | required | relevant            | appearance | constraint | constraint_message  | calculation | choice_filter  | hint | default |
 | ----------------------------- | ----------------- | ---------------------------------- | -------- | ------------------- | ---------- | ---------- | ------------------- | ----------- | -------------- | ---- | ------- |
+| begin group                   | contact           | Contact |
+| hidden                        | name              | name  |
+| end group|
+| calculate                     | patient_name      | NO_LABEL  |   |   |   |   |   | ../contact/name   |   |   |
 | begin group                   | group_assessment  | Assessment                         |          |                     |            |            |                     |             |                |      |         |
 | select_one yes_no             | visited_hf             | Did ${patient_name} go to a health facility for treatment? | yes      |                     |            |            |                     |             |                |      |         |
 | select_one progress_since_last_visit   | progress    | How is ${patient_name}'s condition since the last visit?     | yes      | ${visited_hf} = 'yes'    |            |            |                     |             |                |      |         |


### PR DESCRIPTION
Fixes #511  

The reference form was missing `patient_name` calculate field, hence if somebody followed the exmple, they'd run into the problem. This has been fixed. 