### PR TITLE
Correcting example code for `defaultResolvedIf`

### DIFF
--- a/content/en/apps/reference/tasks.md
+++ b/content/en/apps/reference/tasks.md
@@ -240,7 +240,7 @@ You can also use `this.definition.defaultResolvedIf` inside the `resolvedIf` def
 
 ```js
 resolvedIf: function (contact, report, event, dueDate) {
-  return this.defaultResolvedIf(contact, report, event, dueDate) && otherConditions;
+  return this.definition.defaultResolvedIf(contact, report, event, dueDate) && otherConditions;
 }
 ```
 


### PR DESCRIPTION
The guide text says:
> You can also use `this.definition.defaultResolvedIf`

But the code snippet shows: `this.defaultResolvedIf`, which does not work