### PR TITLE
169 - Dropping support for Android 4.4

### DIFF
--- a/content/en/core/guides/android/branding.md
+++ b/content/en/core/guides/android/branding.md
@@ -9,7 +9,7 @@ description: >
 {{% pageinfo %}}
 This tutorial will take you through building a CHT Android Application off the existing wrapper.
 
-The cht-android application is a thin wrapper to load the CHT Core Framework web application in a webview.
+The cht-android application is a thin wrapper to load the CHT Core Framework web application in a WebView.
 
 You will be adding a new android flavor based off the [CHT Android](https://github.com/medic/cht-android).
 {{% /pageinfo %}}
@@ -198,11 +198,11 @@ If you want to start over because some of the parameters were wrong, just execut
 
 2. Execute `make org=new_brand keyprint` to see the certificate content, like the org name, the certificate fingerprints, etc.
 
-3. Sign your app! try locally to build the app with the certificate. To create the Webview versions of the .apk files: `make org=new_brand flavor=New_brandWebview assemble`. The "release" files signed should be placed in `build/outputs/apk/new_brandWebview/release/`. To ensure the files were signed with the right signature execute `make keyprint-apk`, it will check the certificate of the first apk file under the `build/` folder:
+3. Sign your app! try locally to build the app with the certificate. To create the .apk files run: `make org=new_brand flavor=New_brand assemble`. The "release" files signed should be placed in `build/outputs/apk/new_brand/release/`. To ensure the files were signed with the right signature execute `make keyprint-apk`, it will check the certificate of the first apk file under the `build/` folder:
 
    ```
    $ make keyprint-apk 
-   apksigner verify -v --print-certs build/outputs/apk/new_brandWebview/release/cht-android-SNAPSHOT-new_brand-webview-armeabi-v7a-release.apk
+   apksigner verify -v --print-certs build/outputs/apk/new_brand/release/cht-android-SNAPSHOT-new_brand-arm64-v8a-release.apk
    ... ...
    Verified using v2 scheme (APK Signature Scheme v2): true
    ... ...
@@ -210,7 +210,7 @@ If you want to start over because some of the parameters were wrong, just execut
    Signer #1 certificate SHA-256 digest: 7f072b...
    ```
 
-Also do the same for the bundle format: build and verify, despite the AAB are not useful for local development. In our example, execute first `make org=new_brand flavor=New_brandWebview bundle`, and then `make keyprint-bundle` to see the signature of one of the `.aab` files generated.
+Also do the same for the bundle format: build and verify, despite the AAB are not useful for local development. In our example, execute first `make org=new_brand flavor=New_brand bundle`, and then `make keyprint-bundle` to see the signature of one of the `.aab` files generated.
 
 Because the files generated here are signed with the same key that you are going to use in CI, and the files produced in CI will be uploaded to the Play Store later, any file generated locally following the steps above will be compatible with any installation made from the Play Store, means that if a user install the app from the Play Store, and then we want to replace the installation with an alpha version generated in CI or a local version generated in dev environment, it will work without requiring the user to uninstall the app and lost the data.
 

--- a/content/en/core/guides/android/development-setup.md
+++ b/content/en/core/guides/android/development-setup.md
@@ -97,9 +97,9 @@ To install the version 31.0.0: `sdkmanager --install 'build-tools;31.0.0'`. Then
 
 _Only CHT Android_
 
-Some `make` targets support the flavor and the rendering engine as `make flavor=[Flavor][Engine] [task]`, where `[Flavor]` is the branded version with the first letter capitalized and the `[Engine]` is either `Webview` or `Xwalk`. The `[task]` is the action to execute: `deploy`, `assemble`, `lint`, etc.
+Some `make` targets support the flavor as `make flavor=[Flavor] [task]`, where `[Flavor]` is the branded version with the first letter capitalized. The `[task]` is the action to execute: `deploy`, `assemble`, `lint`, etc.
 
-The default value for `flavor` is `UnbrandedWebview`, e.g. executing `make deploy` will assemble and install that flavor, while executing `make flavor=MedicmobilegammaXwalk deploy` will do the same for the _Medicmobilegamma_ brand and the `Xwalk` engine.
+The default value for `flavor` is `Unbranded`, e.g. executing `make deploy` will assemble and install that flavor, while executing `make flavor=Medicmobilegamma deploy` will do the same for the _Medicmobilegamma_ brand.
 
 See the [Makefile](https://github.com/medic/cht-android/blob/master/Makefile) for more details.
 
@@ -111,11 +111,11 @@ For CHT Android app use:
 
     $ make assemble
 
-The command above builds and assembles the _debug_ and _release_ APKs of the Unbranded Webview version of the app.
+The command above builds and assembles the _debug_ and _release_ APKs of the Unbranded version of the app.
 
-Each APK will be generated and stored in `build/outputs/apk/[flavor][Engine]/[debug|release]/`, for example after assembling the _Simprints Webview_ flavor with `make flavor=SimprintsWebview assemble`, the _release_ versions of the APKs generated are stored in `build/outputs/apk/simprintsWebview/release/`.
+Each APK will be generated and stored in `build/outputs/apk/[flavor]/[debug|release]/`, for example after assembling the _Simprints_ flavor with `make flavor=Simprints assemble`, the _release_ versions of the APKs generated are stored in `build/outputs/apk/simprints/release/`.
 
-To assemble other flavors, use the following command: `make flavour=[Flavor][Engine] assemble`. See the [Flavor selection](#flavor-selection) section for more details about `make` commands.
+To assemble other flavors, use the following command: `make flavour=[Flavor] assemble`. See the [Flavor selection](#flavor-selection) section for more details about `make` commands.
 
 To create the `.aab` bundle file, use `make bundle`, although signed versions are generated when [releasing]({{< ref "core/guides/android/releasing" >}}), and the Play Store requires the AAB to be signed with the right key.
 
@@ -129,7 +129,7 @@ To execute unit tests: `make test` (static checks are also executed).
 
 _Only CHT Android_
 
-To only execute the **linter checks**, run: `make lint`. To perform the same checks for the _XView_ source code, use: `make flavor=UnbrandedXwalk lint` instead.
+To only execute the **linter checks**, run: `make lint`.
 
 #### Instrumentation Tests
 
@@ -159,7 +159,7 @@ Refer to the [CHT Core Developer Guide](https://github.com/medic/cht-core/blob/m
 
 ### Android Studio
 
-The [Android Studio](https://developer.android.com/studio) can be used to build and launch the app instead. Be sure to select the right flavor and rendering engine from the _Build Variants_ dialog (see [Change the build variant](https://developer.android.com/studio/run#changing-variant)). To launch the app in an emulator, you need to uncomment the code that has the strings for the `x86` or the `x86_64` architecture in the `android` / `splits` / `include` sections of the `build.gradle` file.
+The [Android Studio](https://developer.android.com/studio) can be used to build and launch the app instead. Be sure to select the right flavor from the _Build Variants_ dialog (see [Change the build variant](https://developer.android.com/studio/run#changing-variant)). To launch the app in an emulator, you need to uncomment the code that has the strings for the `x86` or the `x86_64` architecture in the `android` / `splits` / `include` sections of the `build.gradle` file.
 
 ### Artifact formats
 
@@ -170,15 +170,7 @@ When building the app there are two output formats you can use: Android App Bund
 _Only CHT Android_
 
 The [publish](https://github.com/medic/cht-android/blob/master/.github/workflows/publish.yml) script in CI produces multiple AABs for publishing to the **Google Play Store**, so the generated `.aab` files need to be uploaded instead of the `.apk` files if the Play Store require so. Old apps published for the first time before Aug 1,  2021 can be updated with the APK format.
-
-For each flavor two bundles are generated, one for each rendering engine: _Webview_ and _Xwalk_. When distributing via the Play Store using the bundle files, upload all AABs and it will automatically choose the right one for the target device.
-
-The AABs are named as follows: `cht-android-{version}-{brand}-{rendering-engine}-release.aab`.
-
-| Rendering engine | Android version |
-|------------------|-----------------|
-| `webview`        | 10+             |
-| `xwalk`          | 4.4 - 9         |
+If distributing AABs via the Play Store, upload all AABs and it will automatically choose the right one for the target device. The AABs are named as follows: `cht-android-{version}-{brand}-release.aab`.
 
 #### APKs
 
@@ -188,11 +180,9 @@ If distributing APKs via the Play Store, upload all APKs and it will automatical
 
 To help you pick which APK to install, you can find information about the version of Android and the CPU in the About section of the phone's settings menu.
 
-The APKs are named as follows: `cht-android-{version}-{brand}-{rendering-engine}-{instruction-set}-release.apk`.
+The APKs are named as follows: `cht-android-{version}-{brand}-{instruction-set}-release.apk`.
 
-| Rendering engine | Instruction set | Android version | Notes                                                       |
-|------------------|-----------------|-----------------|-------------------------------------------------------------|
-| `webview`        | `arm64-v8a`     | 10+             | Preferred. Use this APK if possible.                        |
-| `webview`        | `armeabi-v7a`   | 10+             | Built but not compatible with any devices. Ignore this APK. |
-| `xwalk`          | `arm64-v8a`     | 4.4 - 9         |                                                             |
-| `xwalk`          | `armeabi-v7a`   | 4.4 - 9         |                                                             |
+| Instruction set | Android version | Notes                                                       |
+|-----------------|-----------------|-------------------------------------------------------------|
+| `arm64-v8a`     | 5+              | Preferred. Use this APK if possible.                        |
+| `armeabi-v7a`   | 5+              | Built as support for older devices, ignore if possible.     |


### PR DESCRIPTION
# Description

This PR:
- Removes references of XWalk and Webview since we don't have 2 versions anymore. 

CHT-Android PR: https://github.com/medic/cht-android/pull/236

Ticket:
https://github.com/medic/cht-android/issues/169

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
