### PR TITLE
Add index for Tasks

### DIFF
--- a/content/en/apps/guides/tasks/_index.md
+++ b/content/en/apps/guides/tasks/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Tasks"
+linkTitle: "Tasks"
+weight: 100
+description: >
+ Building and managing Tasks and their data
+---


### PR DESCRIPTION
For #596

Groups the existing task guides that were grouped in a file system folder, but weren't represented in the tree menu.