### PR TITLE
Updating references from "master" to "main"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 
 on: [push, pull_request]
 
-name: Test site and push live if we're on Master
+name: Test site and push live if we're on Main
 jobs:
   BuildLinkCheckPushLive:
     name:
@@ -38,12 +38,12 @@ jobs:
       - name: All Branches - Test For Broken Builds in Hugo
         run: hugo
 
-      - name: Master Branch Only - Build for prod with minify
-        if: github.ref == 'refs/heads/master'
+      - name: Main Branch Only - Build for prod with minify
+        if: github.ref == 'refs/heads/main'
         run: env HUGO_ENV="production" hugo --minify
 
-      - name: Master Branch Only - Deploy to GH pages
-        if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Main Branch Only - Deploy to GH pages
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           personal_token: ${{ secrets.DEPOLY_TO_SITE}}
@@ -51,10 +51,10 @@ jobs:
           publish_dir: ./public
           user_name: medic-ci
           user_email: medic-ci@github
-          publish_branch: master
+          publish_branch: main
 
-      - name: Master Branch Only - Report errors to Slack, if any
-        if: ${{ github.ref == 'refs/heads/master' && failure() }}
+      - name: Main Branch Only - Report errors to Slack, if any
+        if: ${{ github.ref == 'refs/heads/main' && failure() }}
         uses: rtCamp/action-slack-notify@v2.0.2
         env:
           SLACK_WEBHOOK: '${{ secrets.SLACK_WEB_HOOK }}'

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We validate that all links on the docs site work (do not 404) using a tool calle
   - Install [Go](https://golang.org/doc/install) as a prerequisite 
   - Install Muffet: `go get -u github.com/raviqqe/muffet`
   - Ensure you've run `hugo server` so your local docs instance is reachable at http://localhost:1313/
-  - Test the links with the [`muffet.sh`](https://github.com/medic/cht-docs/blob/master/.github/scripts/muffet.sh) script.  If you're in the root of this repo, that'd be: `./.github/scripts/muffet.sh` 
+  - Test the links with the [`muffet.sh`](https://github.com/medic/cht-docs/blob/main/.github/scripts/muffet.sh) script.  If you're in the root of this repo, that'd be: `./.github/scripts/muffet.sh` 
   
 It should take about 60 seconds depending on your Internet connection. If Muffet returns no output, you have no broken links, congrats! 
 
@@ -41,4 +41,4 @@ _Note_: The `muffet.sh` script here is the identical script we run on GitHub. If
 
 ## Continuous Deployment
 
-All changes to `master` branch run a [GitHub action](.github/workflows/ci.yml) to first check for any broken links ([per above](#link-checking-optional)) and then deploy to the documentation site: [docs.communityhealthtoolkit.org](https://docs.communityhealthtoolkit.org)
+All changes to `main` branch run a [GitHub action](.github/workflows/ci.yml) to first check for any broken links ([per above](#link-checking-optional)) and then deploy to the documentation site: [docs.communityhealthtoolkit.org](https://docs.communityhealthtoolkit.org)


### PR DESCRIPTION
https://github.com/medic/cht-core/issues/6574

Updating references from "master" to "main" in a GitHub Action and the readme file.  The repository's default branch has been renamed to "main" already, and it was not breaking, but I considered it was ideal to have these messages and references up to date.