### PR TITLE
Add missing full name in the user doc when creating users

### DIFF
--- a/content/en/apps/tutorials/contact-and-users-2.md
+++ b/content/en/apps/tutorials/contact-and-users-2.md
@@ -72,7 +72,7 @@ Next you are going to create CHW Areas for the Health Facilities you created in 
 
 Create a CSV file named `users.csv` and add the details of the Users, CHW contacts, and CHW Areas you would like to create. Save this file in the base project directory.
 
-| username | password | roles | name | phone | contact.name | contact.phone | contact.sex | contact.age | place.type | place.name | place.parent |
+| username | password | roles | fullname | phone | contact.name | contact.phone | contact.sex | contact.age | place.type | place.name | place.parent |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | mmutiso | q3Z5-vH5 | district_admin | Mary Mutiso | 0712345678 | Mary Mutiso | 0712345678 | Female | 36 | health_center | Mary Mutiso's Area | `<facility uuid>` |
 


### PR DESCRIPTION
# Description
Currently when creating users with cht-conf using the documentation, the user's doc in the medic db doesn't include the user's full name. This is because `full name` is misrepresented as `name` in the tutorial. As a result the user details in the console will not have a `full name` 