### PR TITLE
fix-edit-this-page-404s

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -3,7 +3,7 @@
 {{ $gh_repo := ($.Param "github_repo") }}
 {{ $gh_subdir := ($.Param "github_subdir") }}
 {{ $gh_project_repo := ($.Param "github_project_repo") }}
-{{ $gh_branch := (default "master" ($.Param "github_branch")) }}
+{{ $gh_branch := (default "main" ($.Param "github_branch")) }}
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
 {{ $editURL := printf "%s/edit/%s/content/%s" $gh_repo $gh_branch $pathFormatted }}

--- a/layouts/shortcodes/github-url.html
+++ b/layouts/shortcodes/github-url.html
@@ -2,7 +2,7 @@
 {{ $pathFormatted := replace $path "\\" "/" }}
 {{ $gh_repo := ($.Page.Site.Params.github_repo) }}
 {{ $gh_subdir := ($.Page.Site.Params.github_subdir) }}
-{{ $gh_branch := (default "master" ($.Page.Site.Params.github_branch)) }}
+{{ $gh_branch := (default "main" ($.Page.Site.Params.github_branch)) }}
 {{ if $gh_repo }}
 {{ $githubURL := printf "%s/tree/%s/%s" $gh_repo $gh_branch $pathFormatted }}
 {{ if $gh_subdir }}


### PR DESCRIPTION
this fixes the 404 you get right now when you click the "Edit this page" on any of the docs pages right now:
![image](https://user-images.githubusercontent.com/8253488/152616922-d475d56d-bb16-42d5-aa4f-25e734c48952.png)

hat trick of: `commit message == branch name == pull request name` all "fix-edit-this-page-404s" \o/

@abbyad - bonus points for the hockey reference?!