### PR TITLE
Cht-android coverage report

### DIFF
--- a/content/en/core/guides/android/development-setup.md
+++ b/content/en/core/guides/android/development-setup.md
@@ -123,7 +123,12 @@ To clean the APKs and compiled resources: `make clean`.
 
 ### Testing
 
-To execute unit tests: `make test` (static checks are also executed).
+To execute unit tests, run: `make test` (static checks are also executed).
+
+To generate a unit test coverage report, run: `make test-coverage`.
+
+Find the generated report in:
+`build/reports/jacoco/makeUnbrandedDebugUnitTestCoverageReport/html/index.html`
 
 #### Static checks
 

--- a/content/en/core/guides/android/development-setup.md
+++ b/content/en/core/guides/android/development-setup.md
@@ -123,7 +123,7 @@ To clean the APKs and compiled resources: `make clean`.
 
 ### Testing
 
-To execute unit tests, run: `make test` (static checks are also executed).
+To execute unit tests and static analysis, run: `make test`.
 
 To generate a unit test coverage report, run: `make test-coverage`.
 


### PR DESCRIPTION
# Description
This PR adds information about how to generate a coverage report and where to find the report in cht-android
[CHT-Android PR](https://github.com/medic/cht-android/pull/246)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.