### PR TITLE
Make local setup tutorial consistent with the docker guide

### DIFF
--- a/content/en/apps/tutorials/local-setup.md
+++ b/content/en/apps/tutorials/local-setup.md
@@ -65,7 +65,7 @@ docker-compose up
 
 {{< figure src="medic-login.png" link="medic-login.png" class="right col-6 col-lg-8" >}}
 
-Once the command is done running, navigate to [https://localhost](https://localhost) with the Google Chrome browser and login with the default username `medic` and default password `password`. 
+Once the command is finished, navigate to [https://localhost](https://localhost) with the Google Chrome browser and login with the default username `medic` and default password `password`. 
 
 You might get an error "Your connection is not private" (see [screenshot](./privacy.error.png)). Click "Advanced" and then click "Proceed to localhost".
 

--- a/content/en/apps/tutorials/local-setup.md
+++ b/content/en/apps/tutorials/local-setup.md
@@ -22,7 +22,7 @@ By the end of the tutorial you should be able to:
 
 ## Brief Overview of Key Concepts
 
-The *CHT Core Framework* makes it faster to build full-featured, scalable digital health apps by providing a foundation developers can build on. These apps can support most languages, are [offline-first]({{< ref "core/overview/offline-first" >}}), and work on basic phones (via SMS), smartphones, tablets, and computers.
+The *CHT Core Framework* makes it faster to build full-featured, scalable digital health apps by providing a foundation developers can build on. These apps can support most languages, are [Offline-First]({{< ref "core/overview/offline-first" >}}), and work on basic phones (via SMS), smartphones, tablets, and computers.
 
 *CHT Project Configurer* also known as ***cht-conf*** is command-line interface tool to manage and configure CHT apps.
 

--- a/content/en/apps/tutorials/local-setup.md
+++ b/content/en/apps/tutorials/local-setup.md
@@ -12,7 +12,7 @@ relatedContent: >
 ---
 
 {{% pageinfo %}}
-This tutorial will take you through setting up a local environment to build and test CHT applications on CHT version 3.9.1. This includes setting up the necessary tools to download and run the CHT public docker image as well as a command line interface tool to manage and build CHT apps.
+This tutorial will take you through setting up a local environment to build and test CHT applications on CHT version 3.9.0. This includes setting up the necessary tools to download and run the CHT public docker image as well as a command line interface tool to manage and build CHT apps.
 
 By the end of the tutorial you should be able to:
 
@@ -20,12 +20,11 @@ By the end of the tutorial you should be able to:
 - Upload default settings to localhost
 {{% /pageinfo %}}
 
-
 ## Brief Overview of Key Concepts
 
-*CHT Core Framework* The Core Framework makes it faster to build full-featured, scalable digital health apps by providing a foundation developers can build on. These apps can support most languages, are [Offline-First]({{< ref "core/overview/offline-first" >}}), and work on basic phones (via SMS), smartphones, tablets, and computers.
+The *CHT Core Framework* makes it faster to build full-featured, scalable digital health apps by providing a foundation developers can build on. These apps can support most languages, are [offline-first]({{< ref "core/overview/offline-first" >}}), and work on basic phones (via SMS), smartphones, tablets, and computers.
 
-*CHT Project Configurer* a.k.a ***cht-conf*** is command-line interface tool to manage and configure CHT apps.
+*CHT Project Configurer* also known as ***cht-conf*** is command-line interface tool to manage and configure CHT apps.
 
 *Docker* is a tool designed to make it easier to create, deploy, and run applications by using containers.
 
@@ -37,22 +36,28 @@ To read more about these concepts, see our [Docker Setup guide]({{< relref "core
 
 Before you begin, you need to have some useful software and tools that are required for things to work:
 
-* [nodejs](https://nodejs.org/en/) version 12
-* [npm](https://www.npmjs.com/get-npm)
-* [git](https://git-scm.com/downloads) or the [Github Desktop](https://desktop.github.com/)
-* [docker and docker-compose]({{< relref "apps/guides/hosting/requirements#docker" >}}).
+- [nodejs](https://nodejs.org/en/) version 12
+- [npm](https://www.npmjs.com/get-npm)
+- [git](https://git-scm.com/downloads) or the [Github Desktop](https://desktop.github.com/)
+- [docker and docker-compose]({{< relref "apps/guides/hosting/requirements#docker" >}}).
 
 ## Implementation Steps
 
 Now that you have the dependent tools and software installed, you are ready to set up your CHT local environment.
 
+### 1. Create docker-compose.yml
 
+Open your terminal and navigate to your working folder. Run the command:
 
-### 1. Install the Core Framework
+```shell
+curl -o docker-compose.yml https://raw.githubusercontent.com/medic/cht-core/master/docker-compose.yml
+```
 
-Check out the [cht-core respository](https://github.com/medic/cht-core) to your local machine. This can be done either by using the [Github Desktop app](https://desktop.github.com/) or by running the following command in the directory where you want the CHT code: `git clone https://github.com/medic/cht-core.git`. Checking out the repo will create a `cht-core` directory.
+This will create a copy of the `docker-compose.yml` file from `cht-core`.
 
-Open your terminal and navigate to the `cht-core` directory, where you should see the `docker-compose.yml` file. Run the command:
+{{% alert title="Note" %}} You can also copy the content of the docker-compose.yml file from this [link](https://raw.githubusercontent.com/medic/cht-core/master/docker-compose.yml). {{% /alert %}}
+
+Run the following command inside the directory that you saved the `docker-compose.yml`:
 
 ```shell
 docker-compose up
@@ -60,13 +65,17 @@ docker-compose up
 
 {{< figure src="medic-login.png" link="medic-login.png" class="right col-6 col-lg-8" >}}
 
-Once the command is done running, navigate to [https://localhost](https://localhost) with the Google Chrome browser and login with the default username `medic` and default password `password`. You will get an error "Your connection is not private" (see [screenshot](./privacy.error.png)). Click "Advanced" and then click "Proceed to localhost".
+Once the command is done running, navigate to [https://localhost](https://localhost) with the Google Chrome browser and login with the default username `medic` and default password `password`. 
+
+You might get an error "Your connection is not private" (see [screenshot](./privacy.error.png)). Click "Advanced" and then click "Proceed to localhost".
+
 If you are using Mac you will not be able to find the "Proceed to localhost" link in Chrome, to bypass that error just click anywhere on the denial page and type "thisisunsafe".
+
 This error can be fixed in step 5 below.
 
-If you encounter an error `bind: address already in use`, see the [Port Conflicts section]({{< relref "core/guides/docker-setup#port-conflicts" >}}) in our Docker Setup guide.
+If you encounter an error `bind: address already in use`, see the [Port Conflicts section]({{< relref "core/guides/docker-setup#port-conflicts" >}}) in the Docker Setup guide.
 
-This CHT instance is empty and has no data in it.  While you're free to explore and add your own data, in step 3 below we'll upload sample data.  Proceed to step 2 to install `cht-conf` which is needed to upload the test data.
+This CHT instance is empty and has no data in it. While you're free to explore and add your own data, in step 3 below we will upload sample data. Proceed to step 2 to install `cht-conf` which is needed to upload the test data.
 
 <br clear="all">
 
@@ -97,18 +106,24 @@ By default, the CHT will have the [Maternal & Newborn Health Reference Applicati
 
 {{< figure src="test.data.png" link="test.data.png" class="right col-3 col-lg-6" >}}
 
+- Clone `cht-core` on your computer using the following command:
+
+```shell
+git clone https://github.com/medic/cht-core.git
+```
+
 - Navigate your terminal to the `cht-core/config/default` directory. This is where the reference application is stored.
 - Run the following `cht-conf` command to compile and upload default test data to your local instance:
 
 ```shell
-cht --url=https://medic:password@localhost --accept-self-signed-certs csv-to-docs upload-docs`.
+cht --url=https://medic:password@localhost --accept-self-signed-certs csv-to-docs upload-docs
 ```
 
 With the test data uploaded, log back into your CHT instance and note the "Test Health Facility" and related data.
 
 <br clear="all">
 
- *****
+*****
 
 ### 4. Create and Upload a Blank Project
 
@@ -138,14 +153,13 @@ cht --url=https://medic:password@localhost --accept-self-signed-certs
 
 {{< figure src="all-actions-completed.png" link="all-actions-completed.png" class="right col-6 col-lg-8" >}}
 
-
 `accept-self-signed-certs` tells cht-conf that it’s OK that the server’s certificate isn’t signed properly, which will be the case when using docker locally.
 
 Once you have run the above command it should complete with the message: `INFO All actions completed.`.
 
 <br clear="all">
 
- *****
+*****
 
 ### 5. Optional: Install Valid TLS Certificate
 
@@ -163,7 +177,7 @@ To see what a before and after looks like, note the screenshot to the left which
 
 The output of `add-local-ip-certs-to-docker.sh` looks like this:
 
-```
+```text
 Debug: Service 'medic-core/nginx' exited with status 143
 Info: Service 'medic-core/nginx' restarted successfully
 Success: Finished restarting services in package 'medic-core'
@@ -179,3 +193,6 @@ When using `cht-conf` you can now drop the use of `--accept-self-signed-certs`. 
 
 - [How do I upgrade to a higher version of the webapp?](https://forum.communityhealthtoolkit.org/t/cant-upgrade-to-3-8-version/608)
 - [How do I access the instance remotely?](https://forum.communityhealthtoolkit.org/t/unable-to-install-core-framework-in-cloud-instance/533)
+- [Error 'No module named pip' when installing cht-conf](https://forum.communityhealthtoolkit.org/t/installing-cht-conf/1593)
+- [CouchDB failed to start properly](https://forum.communityhealthtoolkit.org/t/couchdb-failed-to-start-properly/1683)
+- [Enable adding contacts in a blank project](https://forum.communityhealthtoolkit.org/t/enable-adding-contacts-in-a-blank-project-deployed-onlocal-test-environment-for-cht-instance/1652)


### PR DESCRIPTION
Step 1 in [this tutorial](https://docs.communityhealthtoolkit.org/apps/tutorials/local-setup/) was inconsistent with the [Docker Image Setup guide](https://docs.communityhealthtoolkit.org/core/guides/docker-setup/). This PR updates that step and consequently step 3 to be consistent with the guide. It also fixes some formatting issues, typos and updates the frequently asked questions.