### PR TITLE
Update medic conf to cht-conf

### DIFF
--- a/content/en/apps/tutorials/contact-and-users-1.md
+++ b/content/en/apps/tutorials/contact-and-users-1.md
@@ -11,7 +11,7 @@ relatedContent: >
 ---
 
 {{% pageinfo %}}
-In this tutorial you will learn how to create and edit contacts and their associated users in and application built with the CHT using the default contact creation forms. This will help you get familiar with the UI of the webapp as well as some features and functionality. If you are already comfortable with this, you can skip to [part 2, which covers manipulating contacts and their associated documents using medic conf]({{% ref "apps/tutorials/contact-and-users-2" %}}).
+In this tutorial you will learn how to create and edit contacts and their associated users in and application built with the CHT using the default contact creation forms. This will help you get familiar with the UI of the webapp as well as some features and functionality. If you are already comfortable with this, you can skip to [part 2, which covers manipulating contacts and their associated documents using cht-conf]({{% ref "apps/tutorials/contact-and-users-2" %}}).
 {{% /pageinfo %}}
 
 


### PR DESCRIPTION
The [Contact and User Management - Part 1](https://docs.communityhealthtoolkit.org/apps/tutorials/contact-and-users-1/) had a reference to 'medic conf' instead of the updated 'cht-conf'.