### PR TITLE
fix partners conf filename reference

### DIFF
--- a/content/en/apps/tutorials/application-graphics.md
+++ b/content/en/apps/tutorials/application-graphics.md
@@ -83,7 +83,7 @@ If you would like to display a collection of logos representing all of the organ
 
  #### Using cht-conf
 
-Create a `branding.json` file if it doesn't exist. (This may have already been created by the initialise-project-layout command).
+Create a `partners.json` file if it doesn't exist. (This may have already been created by the initialise-project-layout command).
 Edit the file with the following content:
 
 ```json


### PR DESCRIPTION
Hello, I think for the partners logos config, the file that has to be created or edited is `partners.json` instead of `branding.json` 