### PR TITLE
Fix search page

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -5,17 +5,13 @@ identifier: "docs"
 weight: 1
 cascade:
 - _target:
-  path: "/**"
+    path: "/**"
   kind: "page"
   type: "docs"
 - _target:
-  path: "/**"
+    path: "/**"
   kind: "section"
   type: "docs"
-- _target:
-  path: "/**"
-  kind: "section"
-  type: "home"
 ---
 
 {{% pageinfo %}}

--- a/content/en/search.md
+++ b/content/en/search.md
@@ -2,5 +2,6 @@
 title: Search Results
 linkTitle: " "
 layout: search
+type: search
 toc_hide: true
 ---

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,34 @@
+<!-- Copied from docsy theme's docs/baseof.  Included here as default so it is used for the search page. -->
+<!-- Docs page: https://github.com/google/docsy/blob/743d9dae47de30b15b4e76d9f2b5ad7d82697627/layouts/docs/baseof.html -->
+<!doctype html>
+<html itemscope itemtype="http://schema.org/WebPage" lang="{{ .Site.Language.Lang }}" class="no-js">
+<head>
+    {{ partial "head.html" . }}
+</head>
+<body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+<header>
+    {{ partial "navbar.html" . }}
+</header>
+<div class="container-fluid td-outer">
+    <div class="td-main">
+        <div class="row flex-xl-nowrap">
+            <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
+                {{ partial "sidebar.html" . }}
+            </aside>
+            <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
+                {{ partial "page-meta-links.html" . }}
+                {{ partial "toc.html" . }}
+                {{ partial "taxonomy_terms_clouds.html" . }}
+            </aside>
+            <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+                {{ partial "version-banner.html" . }}
+                {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
+                {{ block "main" . }}{{ end }}
+            </main>
+        </div>
+    </div>
+    {{ partial "footer.html" . }}
+</div>
+{{ partial "scripts.html" . }}
+</body>
+</html>

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,0 +1,28 @@
+{{/* Modified from docsy theme */}}
+{{/* Search page: https://github.com/google/docsy/blob/743d9dae47de30b15b4e76d9f2b5ad7d82697627/layouts/_default/search.html */}}
+{{ define "main" }}
+<section class="row td-search-result">
+<!--  Tweak column width - https://github.com/medic/cht-docs/commit/47350b49af990db8c9cac20fe23aabe2eb540944 -->
+<!--    <div class="col-12 col-md-8 offset-md-2">-->
+    <div class="col-12 col-xl-10">
+        <h2 class="ml-4">{{ .Title }}</h2>
+        {{ with .Site.Params.gcs_engine_id }}
+        <script>
+          (function() {
+            var cx = '{{ . }}';
+            var gcse = document.createElement('script');
+            gcse.type = 'text/javascript';
+            gcse.async = true;
+            gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+            var s = document.getElementsByTagName('script')[0];
+            s.parentNode.insertBefore(gcse, s);
+          })();
+        </script>
+<!-- Default refinement to Documentation - https://github.com/medic/cht-docs/commit/47350b49af990db8c9cac20fe23aabe2eb540944 -->
+<!--        <gcse:searchresults-only></gcse:searchresults-only>-->
+        <gcse:searchresults-only defaultToRefinement="Documentation"></gcse:searchresults-only>
+        {{ end }}
+    </div>
+</section>
+
+{{ end }}


### PR DESCRIPTION
The [Hugo/Docsy uplift](https://github.com/medic/cht-docs/pull/731) accidentally broke the search page completely.  :cry: 

Basically, the cascading front-matter from the base `_index.md` file caused the `search.md` file to not get treated as a search page. I have made the necessary corrections to the front-matter to fix this. 

However, I also noticed that the search page no longer contained the sidebars. After some investigating I was able to conclude that this was caused by the unintentional deletion of a couple of the default layout files during the refactor.  (Thanks to a a massive oversight on my part I did not realize they were necessary for the proper layout of the Search page.)  I have restored these pages and now the search page should behave as expected!