### PR TITLE
Fix list pages so that Related Content section is displayed

### DIFF
--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,5 +1,5 @@
-<!-- Modified from docsy theme to show related content -->
-<!-- https://github.com/google/docsy/blob/c65715725ee992cd4e59aeefe0f66df80b2eb4ea/layouts/docs/list.html -->
+{{/* Modified from docsy theme to show related content */}}
+{{/* https://github.com/google/docsy/blob/c65715725ee992cd4e59aeefe0f66df80b2eb4ea/layouts/docs/list.html */}}
 {{ define "main" }}
 <div class="td-content">
 	<h1>{{ .Title }}</h1>


### PR DESCRIPTION
Updates the location of the `list.html` page template so that it is actually used.  Hugo will try to use templates from `layouts/docs` before falling back to `layouts/_default`.  So, the [Docsy list template](https://github.com/google/docsy/blob/main/layouts/docs/list.html) was getting resolved first and was not overridden by our custom `list.html`.  

Understandably, this would break the "Related Content" section for any list pages (e.g. [`apps/features/integrations`](https://docs.communityhealthtoolkit.org/apps/features/integrations/)).  However, I do not understand exactly why this broke the related content for pages such as [`apps/features/contacts`](https://docs.communityhealthtoolkit.org/apps/features/contacts/) since that does not fit my understanding of a "list" page....  (This is further complicated by the fact that similar pages like [`apps/features/integrations/android`](https://docs.communityhealthtoolkit.org/apps/features/integrations/android/) are not broken (since they use the `content.html` template as expected...)  My best guess is this is a bug (feature?) in Hugo that is caused by the fact that [`apps/features/contacts`](https://docs.communityhealthtoolkit.org/apps/features/contacts/) sits at the _same level_ in the hierarchy as a list page: [`apps/features/integrations`](https://docs.communityhealthtoolkit.org/apps/features/integrations/).  Perhaps that triggers Hugo to treat all of the pages at that level as lists...

Either way, it is enough to say that fixing the `list.html` was enough to cause the "Related Content" to be displayed everywhere that it was missing!

Closes https://github.com/medic/cht-docs/issues/758