### PR TITLE
Update app-developer.md: switch links

### DIFF
--- a/content/en/apps/guides/hosting/app-developer.md
+++ b/content/en/apps/guides/hosting/app-developer.md
@@ -8,7 +8,7 @@ description: >
 
 {{% alert title="Note" %}} This guide assumes you are a CHT app developer wanting to either run concurrent instances of the CHT, or easily be able to switch between different instances without loosing any data while doing so. To do development on the CHT core itself, see the [development guide]({{< relref "apps/guides/hosting/core-developer.md" >}}). 
 
-To deploy the CHT in production, see either [AWS hosting]({{< relref "apps/guides/hosting/self-hosting.md" >}}) or [Self hosting]({{< relref "apps/guides/hosting/ec2-setup-guide.md" >}}){{% /alert %}}
+To deploy the CHT in production, see either [AWS hosting]({{< relref "apps/guides/hosting/ec2-setup-guide.md" >}}) or [Self hosting]({{< relref "apps/guides/hosting/self-hosting.md" >}}){{% /alert %}}
 
 
 ## Getting started


### PR DESCRIPTION
The links for self-hosting and AWS hosting were switched. Fixed.