### PR TITLE
convert all compose files to use `docker-compose-developer-3.x-only.yml` until 4.0 is out

### DIFF
--- a/content/en/apps/guides/hosting/app-developer.md
+++ b/content/en/apps/guides/hosting/app-developer.md
@@ -15,7 +15,7 @@ To deploy the CHT in production, see either [AWS hosting]({{< relref "apps/guide
 
 ## Getting started
 
-Be sure to meet the [CHT hosting requirements]({{< relref "apps/guides/hosting/requirements" >}}) first. As well, if any other `medic-os` instances using [the main `docker-compose.yml` file](https://github.com/medic/cht-core/blob/master/docker-compose.yml) are running locally, stop them otherwise port, storage volume and container name conflicts may occur.
+Be sure to meet the [CHT hosting requirements]({{< relref "apps/guides/hosting/requirements" >}}) first. As well, if any other `medic-os` instances using [the main `docker-compose-developer-3.x-only.yml` file](https://raw.githubusercontent.com/medic/cht-core/master/scripts/docker-helper/docker-compose-developer-3.x-only.yml) are running locally, stop them otherwise port, storage volume and container name conflicts may occur.
 
 After meeting these requirements, download the developer YAML file in the directory you want to store them:
 

--- a/content/en/apps/guides/hosting/self-hosting.md
+++ b/content/en/apps/guides/hosting/self-hosting.md
@@ -8,6 +8,7 @@ relatedContent: >
   apps/guides/hosting/ec2-setup-guide
 ---
 
+{{% alert title="Note" %}} This guide will only work with CHT 3.x instances.  It will be updated to work with 4.x instances at a later date.{{% /alert %}}
 
 Whether run on bare-metal or in a cloud provider, the Community Health Toolkit (CHT) core framework has been packaged into a docker container to make it portable and easy to install. It is available from [dockerhub](https://hub.docker.com/r/medicmobile/medic-os). To learn more how to work with docker you could follow the tutorial [here](https://docker-curriculum.com/#getting-started) and the cheat sheet [here](https://www.docker.com/sites/default/files/d8/2019-09/docker-cheat-sheet.pdf).  
 
@@ -17,10 +18,10 @@ Whether run on bare-metal or in a cloud provider, the Community Health Toolkit (
 
 The CHT containers are installed using [docker compose](https://docs.docker.com/compose/reference/overview/) so that you can run multiple containers  as a single service.
 
-Start by choosing the location where you would like to save your compose configuration file.  Then create the `docker-compose.yml` file by `cd`ing into the correct directory and running:
+Start by choosing the location where you would like to save your compose configuration file.  Then create the `docker-compose-developer-3.x-only.yml` file by `cd`ing into the correct directory and running:
 
 ```bash
-curl -s -o docker-compose.yml https://raw.githubusercontent.com/medic/cht-core/master/docker-compose.yml
+curl -s -o docker-compose.yml https://raw.githubusercontent.com/medic/cht-core/master/scripts/docker-helper/docker-compose-developer-3.x-only.yml
 ```
 
 
@@ -28,16 +29,16 @@ The install requires an admin password that it will configure in the database. Y
 
 `export DOCKER_COUCHDB_ADMIN_PASSWORD=myAwesomeCHTAdminPassword`
 
-You can then run `docker-compose` in the folder where you put your compose  `docker-compose.yml` file. To start, run it interactively to see all the logs on screen and be able to stop the containers with `ctrl` + `c`:
+You can then run `docker-compose` in the folder where you put your compose  `docker-compose-developer-3.x-only.yml` file. To start, run it interactively to see all the logs on screen and be able to stop the containers with `ctrl` + `c`:
 
 ```bash
-sudo docker-compose up 
+sudo docker-compose -f docker-compose-developer-3.x-only.yml up 
 ```
 
 If there are no errors, stop the containers with `ctrl` + `c` and then run it detached with `-d`:
 
 ```bash
-sudo docker-compose up -d
+sudo docker-compose -f docker-compose-developer-3.x-only.yml up -d
 ```
 
 Note In certain shells, `docker-compose` may not interpolate the admin password that was exported in `DOCKER_COUCHDB_ADMIN_PASSWORD`. Check if this is the case by searching the logs in the medic-os dockers instance. If the `docker logs medic-os` command below returns a user and password, then the export above failed, and you should use this user and password to complete the installation:
@@ -74,10 +75,10 @@ If some  instructions were missed and there's a broken CHT deployment, use the c
 1. Remove containers: `docker rm medic-os && docker rm haproxy`
 1. Clean data volume:`docker volume rm medic-data`
 
-    Note: Running `docker-compose -f docker-compose.yml down -v`  would do all the above 3 steps
+    Note: Running `docker-compose -f docker-compose-developer-3.x-only.yml down -v`  would do all the above 3 steps
 1. Prune system: `docker system prune`
 
-After following the above commands, you can re-run docker-compose up and create a clean install:  `docker-compose -f docker-compose.yml up -d`
+After following the above commands, you can re-run docker-compose up and create a clean install:  `docker-compose -f docker-compose-developer-3.x-only.yml up -d`
 
 ### Port Conflicts
 
@@ -107,11 +108,11 @@ services:
 
 Turn off and remove all existing containers that were started:
 
- `sudo docker-compose -f /path/to/docker-compose.yml down`
+ `sudo docker-compose -f /path/to/docker-compose-developer-3.x-only.yml down`
 
 Bring Up the containers in detached mode with the new forwarded ports.
 
- `sudo docker-compose -f /path/to/docker-compose.yml up -d`
+ `sudo docker-compose -f /path/to/docker-compose-developer-3.x-only.yml up -d`
 
 Note: You can  substitute 8080, 444 with whichever ports are free on your host. You would now visit https://localhost:444 to visit your project.
 

--- a/content/en/apps/tutorials/local-setup.md
+++ b/content/en/apps/tutorials/local-setup.md
@@ -20,6 +20,8 @@ By the end of the tutorial you should be able to:
 - Upload default settings to localhost
 {{% /pageinfo %}}
 
+- {{% alert title="Note" %}} This guide will only work with CHT 3.x instances.  It will be updated to work with 4.x instances at a later date.{{% /alert %}}
+
 ## Brief Overview of Key Concepts
 
 The *CHT Core Framework* makes it faster to build full-featured, scalable digital health apps by providing a foundation developers can build on. These apps can support most languages, are [Offline-First]({{< ref "core/overview/offline-first" >}}), and work on basic phones (via SMS), smartphones, tablets, and computers.
@@ -50,17 +52,17 @@ Now that you have the dependent tools and software installed, you are ready to s
 Open your terminal and navigate to your working folder. Run the command:
 
 ```shell
-curl -o docker-compose.yml https://raw.githubusercontent.com/medic/cht-core/master/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/medic/cht-core/master/scripts/docker-helper/docker-compose-developer-3.x-only.yml
 ```
 
-This will create a copy of the `docker-compose.yml` file from `cht-core`.
+This will create a copy of the `docker-compose-developer-3.x-only.yml` file from `cht-core`.
 
-{{% alert title="Note" %}} You can also copy the content of the docker-compose.yml file from this [link](https://raw.githubusercontent.com/medic/cht-core/master/docker-compose.yml). {{% /alert %}}
+{{% alert title="Note" %}} You can also copy the content of the docker-compose.yml file from this [link](https://raw.githubusercontent.com/medic/cht-core/master/scripts/docker-helper/docker-compose-developer-3.x-only.yml). {{% /alert %}}
 
-Run the following command inside the directory that you saved the `docker-compose.yml`:
+Run the following command inside the directory that you saved the `docker-compose-developer-3.x-only.yml`:
 
 ```shell
-docker-compose up
+docker-compose -f docker-compose-developer-3.x-only.yml up
 ```
 
 {{< figure src="medic-login.png" link="medic-login.png" class="right col-6 col-lg-8" >}}

--- a/content/en/core/guides/docker-setup.md
+++ b/content/en/core/guides/docker-setup.md
@@ -7,6 +7,8 @@ description: >
 relevantLinks: >
 ---
 
+{{% alert title="Note" %}} This guide will only work with CHT 3.x instances.  It will be updated to work with 4.x instances at a later date.{{% /alert %}}
+
 This document helps to download and run the public docker image for CHT applications.
 
 ## Install Docker
@@ -15,15 +17,15 @@ Please be sure `docker` and `docker-compose` are [installed]({{< relref "apps/gu
 
 ## Use Docker-Compose:
 
-In the location you would like to host your configuration files, create a file `docker-compose.yml`: 
+In the location you would like to host your configuration files, create a file `docker-compose-developer-3.x-only.yml`: 
 
 1. Use the `curl` command line tool:
     
     ```
-    curl https://raw.githubusercontent.com/medic/cht-core/master/docker-compose.yml
+    curl https://raw.githubusercontent.com/medic/cht-core/master/scripts/docker-helper/docker-compose-developer-3.x-only.yml
     ```
 
-1. Alternately, if you do not have  `curl`, you can [right click this link](https://raw.githubusercontent.com/medic/cht-core/master/docker-compose.yml) and choose "Save link as..." and specify the correct location to save.
+1. Alternately, if you do not have  `curl`, you can [right click this link](https://raw.githubusercontent.com/medic/cht-core/master/scripts/docker-helper/docker-compose-developer-3.x-only.yml) and choose "Save link as..." and specify the correct location to save.
 
 Export a password for admin user named `medic`:
 ```
@@ -32,9 +34,9 @@ export DOCKER_COUCHDB_ADMIN_PASSWORD=<random_pw>
 
 ### Launch docker-compose containers
 
-Inside the directory that you saved the above `docker-compose.yml`, run:
+Inside the directory that you saved the above `docker-compose-developer-3.x-only.yml`, run:
 ```
-docker-compose up
+docker-compose -f docker-compose-developer-3.x-only.yml up
 ```
 {{% alert title="Note" %}}
 In certain shells, docker-compose may not interpolate the admin password that was exported above. In that case, your admin user had a password automatically generated. Note the `New CouchDB Administrative User` and `New CouchDB Administrative Password` in the output terminal. You can retrieve these via running `docker logs medic-os` and searching the terminal.
@@ -70,7 +72,7 @@ Remove containers:
 Clean data volume:
 * `docker volume rm medic-data`
 
-After following the above three commands, you can re-run `docker-compose up` and create a fresh install (no previous data present)
+After following the above three commands, you can re-run `docker-compose -f docker-compose-developer-3.x-only.yml up` and create a fresh install (no previous data present)
 
 ## Port Conflicts
 


### PR DESCRIPTION
@dianabarsan  - thanks for fielding forum posts about this!  while a temporary fix that we'll have revert fix soon, I think worthy while.

Mirrors works in #801 for docs and already merged  [cht-core PR](https://github.com/medic/cht-core/pull/7828)