### PR TITLE
Document MacOS M1 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To install, follow the [installation instructions for your Operating System](htt
 1. Preview your site in your browser at: http://localhost:1313/
 1. As you make changes to the site, your browser will automatically reload your local dev site so you can easily and quickly see your changes.
 
-MacOS users getting `fatal error: pipe failed`, please see our [Troubleshooting guide](./troubleshooting.md).
+MacOS users getting errors when running `hugo server`, please see our [Troubleshooting guide](./troubleshooting.md).
 
 ## Link Checking [Optional]
 

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1,7 +1,8 @@
 # Troubleshooting 
 
-## MacOS Hugo "fatal error: pipe failed"
+## MacOS 
 
+### Hugo "fatal error: pipe failed" 
 MacOS users encountering the `fatal error: pipe failed` error when running `hugo server` need to run these commands:
 
 ```shell
@@ -26,3 +27,17 @@ hugo server
 Save this in file with the `.commmand` suffix (e.g. `cht-docs-server.command`) to enable an easy double clicking to start the server.
 
 Note - be sure to enter your MacOS user password in the terminal when prompted. 
+
+### Hugo "Error: failed to download modules: binary with name "go" not found" 
+MacOS M1 users encountering `Error: failed to download modules: binary with name "go" not found` when running `hugo server` need to install Golang by running:
+
+```shell
+brew install golang
+```
+
+### Hugo "Error: Error building site: POSTCSS"
+MacOS M1 users encountering `Error: Error building site: POSTCSS: failed to transform "scss/main.css" (text/css)` when running `hugo server` need to install `postcss-cli` by running:
+
+```shell
+npm install postcss-cli
+```


### PR DESCRIPTION
While following the instructions for running `cht-docs` locally on a Mac M1, I needed to perform two extra steps to have `hugo server` work properly:

- Install `Golang`
- Install `postcss-cli`

I tried the setup steps on a second Mac M1, and I needed to install only `Golang` to have `hugo` running.

This PR updates the `troubleshooting.md` document with the extra steps I needed to perform, in case someone else bumps into the same errors.