### PR TITLE
Revert build name to fix status image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,9 @@
 
 on: [push, pull_request]
 
-name: Test site and push live if we're on Main
+# This action tests site and pushes live if we're on Main
+# Changes to the `name` will break the build status image in the readme
+name: CHT Documentation Site Build
 jobs:
   BuildLinkCheckPushLive:
     name:


### PR DESCRIPTION
This change will restore the working build status image in the readme, but I am not certain that this is actually how we want to do it. Will **non-**main builds also be represented by this status? If so we need to reconsider this approach.

An alternative is to remove the status image, which seems to have been broken for several years without complaint.
For https://github.com/medic/cht-docs/issues/870