### PR TITLE
Remove relative paths from .env file

### DIFF
--- a/content/en/apps/tutorials/local-setup.md
+++ b/content/en/apps/tutorials/local-setup.md
@@ -58,11 +58,11 @@ Open your terminal and run these commands which will create a directory, downloa
 mkdir -p ~/cht-local-setup/couch-data/ && mkdir -p ~/cht-local-setup/core-couch/ && mkdir -p ~/cht-local-setup/upgrade/
 cd ~/cht-local-setup
 curl -s -o ./core-couch/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:master/docker-compose/cht-core.yml && curl -s -o ./core-couch/cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:master/docker-compose/cht-couchdb.yml && curl -s -o ./upgrade/docker-compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
-cat > ~/cht-local-setup/upgrade/.env << EOF
-DOCKER_CONFIG_PATH=~/cht-local-setup/core-couch/
-COUCHDB_DATA=~/cht-local-setup/data/couch-data 
-CHT_COMPOSE_PATH=~/cht-local-setup/core-couch/
-COUCHDB_USER=medic 
+cat > ${HOME}/cht-local-setup/upgrade/.env << EOF
+DOCKER_CONFIG_PATH=${HOME}/cht-local-setup/core-couch/
+COUCHDB_DATA=${HOME}/cht-local-setup/data/couch-data 
+CHT_COMPOSE_PATH=${HOME}/cht-local-setup/core-couch/
+COUCHDB_USER=medic
 COUCHDB_PASSWORD=password
 EOF
 ```


### PR DESCRIPTION
After [getting feedback](https://github.com/medic/cht-docs/pull/874#issuecomment-1333492313) (inline below too) about using `~` in the `.env` file causes problems, this commit removes the use of `~`:

> @mrjones-plip, just a quick update on this change. Esther re-tried the steps after this doc change and we bumped into a path issue while running the docker-compose up command. We had to replace the ~ with the absolute path for the DOCKER_CONFIG_PATH, COUCHDB_DATA and CHT_COMPOSE_PATH to have the container run correctly.
> 
> FYI @esthermmoturi