### PR TITLE
Move from master to 4.0.1 as  stop gap

### DIFF
--- a/content/en/apps/tutorials/local-setup.md
+++ b/content/en/apps/tutorials/local-setup.md
@@ -57,7 +57,7 @@ Open your terminal and run these commands which will create a directory, downloa
 ```shell
 mkdir -p ~/cht-local-setup/couch-data/ && mkdir -p ~/cht-local-setup/core-couch/ && mkdir -p ~/cht-local-setup/upgrade/
 cd ~/cht-local-setup
-curl -s -o ./core-couch/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:master/docker-compose/cht-core.yml && curl -s -o ./core-couch/cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:master/docker-compose/cht-couchdb.yml && curl -s -o ./upgrade/docker-compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
+curl -s -o ./core-couch/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.0.1/docker-compose/cht-core.yml && curl -s -o ./core-couch/cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.0.1/docker-compose/cht-couchdb.yml && curl -s -o ./upgrade/docker-compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
 cat > ${HOME}/cht-local-setup/upgrade/.env << EOF
 DOCKER_CONFIG_PATH=${HOME}/cht-local-setup/core-couch/
 COUCHDB_DATA=${HOME}/cht-local-setup/data/couch-data 


### PR DESCRIPTION
Until we can figure an easy way to dynamically resolve the latest version, possibly like is [being considered over here](https://github.com/medic/cht-core/pull/7956#issuecomment-1336775724)