### PR TITLE
Update local-setup.md

### DIFF
--- a/content/en/apps/tutorials/local-setup.md
+++ b/content/en/apps/tutorials/local-setup.md
@@ -162,7 +162,6 @@ cht --url=https://medic:password@localhost --accept-self-signed-certs
 ```
 
 If the above command shows an error similar to this one `ERROR Error: Webpack warnings when building contact-summary` you will need to install all the dependencies and libraries it needs, then you need to restart the docker-compose and try again. Run the following to install the dependancies.
-If this error is persistent, please create a new directory and initialise a new project in the new location (outside of your `cht-core` directory tree).
 
 ```shell
 npm ci

--- a/content/en/apps/tutorials/local-setup.md
+++ b/content/en/apps/tutorials/local-setup.md
@@ -160,7 +160,8 @@ Then deploy the blank project onto your local test environment with the command:
 cht --url=https://medic:password@localhost --accept-self-signed-certs
 ```
 
-If the above command shows an error similar to this one `ERROR Error: Webpack warnings when building contact-summary` you will need to install all the dependencies and libraries it needs, then you need to restart the docker-compose and try again.
+If the above command shows an error similar to this one `ERROR Error: Webpack warnings when building contact-summary` you will need to install all the dependencies and libraries it needs, then you need to restart the docker-compose and try again. Run the following to install the dependancies.
+If this error is persistent, please create a new directory and initialise a new project in the new location (this location should not be in your cht-core folder).
 
 ```shell
 npm ci

--- a/content/en/apps/tutorials/local-setup.md
+++ b/content/en/apps/tutorials/local-setup.md
@@ -162,7 +162,7 @@ cht --url=https://medic:password@localhost --accept-self-signed-certs
 ```
 
 If the above command shows an error similar to this one `ERROR Error: Webpack warnings when building contact-summary` you will need to install all the dependencies and libraries it needs, then you need to restart the docker-compose and try again. Run the following to install the dependancies.
-If this error is persistent, please create a new directory and initialise a new project in the new location (this location should not be in your cht-core folder).
+If this error is persistent, please create a new directory and initialise a new project in the new location (outside of your `cht-core` directory tree).
 
 ```shell
 npm ci

--- a/content/en/apps/tutorials/local-setup.md
+++ b/content/en/apps/tutorials/local-setup.md
@@ -146,11 +146,12 @@ With the test data uploaded, log back into your CHT instance and note the "Test 
 
 {{% alert title="Note" %}} This step will erase the default Maternal & Newborn Health Reference Application. {{% /alert %}}
 
-With `cht-conf` you can also create a blank project. This provides you a template from which you can begin working on CHT. To do so, run the following commands:
+
+With `cht-conf` you can also create a blank project. This provides you a template from which you can begin working on CHT. To do so, run the following commands which will create a new directory and initialize it. Be sure to use this directory for all subsequent calls: 
 
 ```shell
-mkdir cht-app-tutorials
-cd cht-app-tutorials
+mkdir ~/cht-app-tutorials
+cd ~/cht-app-tutorials
 cht initialise-project-layout
 ```
 


### PR DESCRIPTION
For more context, we had this issue here on the forum: https://forum.communityhealthtoolkit.org/t/unable-to-push-and-upload-a-blank-project-on-my-local-environment/2427/8

My local set up has issues deploying a blank project on the cht-core location. We replicated this in other local deployments.