### PR TITLE
rename couchdb node name, fix yml name typo, bump cht 4.0.1 -> 4.1.0 in curl

### DIFF
--- a/content/en/apps/guides/hosting/4.x/self-hosting-multiple-nodes.md
+++ b/content/en/apps/guides/hosting/4.x/self-hosting-multiple-nodes.md
@@ -216,7 +216,7 @@ Like we did for Node 1, create `/home/ubuntu/cht/docker-compose.yml` and the `cl
 ```shell
 cd /home/ubuntu/cht/
 curl -s -o ./docker-compose.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.1.0/docker-compose/cht-couchdb.yml
-cat > /home/ubuntu/cht/network-overrides.yml << EOF
+cat > /home/ubuntu/cht/cluster-overrides.yml << EOF
 version: '3.9'
 services:
   couchdb:

--- a/content/en/apps/guides/hosting/4.x/self-hosting-multiple-nodes.md
+++ b/content/en/apps/guides/hosting/4.x/self-hosting-multiple-nodes.md
@@ -104,7 +104,7 @@ DOCKER_CONFIG_PATH=/home/ubuntu/cht/upgrade-service
 CHT_COMPOSE_PATH=/home/ubuntu/cht/compose
 COUCHDB_USER=medic
 COUCHDB_PASSWORD=${couchdb_password}
-COUCHDB_SERVERS=couchdb.1,couchdb.2,couchdb.3
+COUCHDB_SERVERS=couchdb-1.local,couchdb-2.local,couchdb-3.local
 EOF
 ```
 
@@ -116,7 +116,7 @@ The following 2 `curl` commands download CHT version `4.0.1` compose files, whic
 
 ```shell
 cd /home/ubuntu/cht/
-curl -s -o ./compose/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.0.1/docker-compose/cht-core.yml
+curl -s -o ./compose/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.1.0/docker-compose/cht-core.yml
 curl -s -o ./upgrade-service/docker-compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
 ```
 
@@ -188,7 +188,7 @@ Create `/home/ubuntu/cht/docker-compose.yml` on Node 1 by running this code:
 
 ```shell
 cd /home/ubuntu/cht/
-curl -s -o ./docker-compose.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.0.1/docker-compose/cht-couchdb.yml
+curl -s -o ./docker-compose.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.1.0/docker-compose/cht-couchdb.yml
 ```
 
 Now create the override file to have Node 1 join the `cht-net` overlay network we created above. As well, we'll set some `services:` specific overrides:
@@ -198,10 +198,10 @@ cat > /home/ubuntu/cht/cluster-overrides.yml << EOF
 version: '3.9'
 services:
   couchdb:
-    container_name: couchdb.1
+    container_name: couchdb-1.local
     environment:
-      - "SVC_NAME=${SVC1_NAME:-couchdb.1}"
-      - "CLUSTER_PEER_IPS=couchdb.2,couchdb.3"
+      - "SVC_NAME=${SVC1_NAME:-couchdb-1.local}"
+      - "CLUSTER_PEER_IPS=couchdb-2.local,couchdb-3.local"
 networks:
   cht-net:
      driver: overlay
@@ -215,15 +215,15 @@ Like we did for Node 1, create `/home/ubuntu/cht/docker-compose.yml` and the `cl
 
 ```shell
 cd /home/ubuntu/cht/
-curl -s -o ./docker-compose.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.0.1/docker-compose/cht-couchdb.yml
+curl -s -o ./docker-compose.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.1.0/docker-compose/cht-couchdb.yml
 cat > /home/ubuntu/cht/network-overrides.yml << EOF
 version: '3.9'
 services:
   couchdb:
-    container_name: couchdb.2
+    container_name: couchdb-2.local
     environment:
-      - "SVC_NAME=couchdb.2"
-      - "COUCHDB_SYNC_ADMINS_NODE=${COUCHDB_SYNC_ADMINS_NODE:-couchdb.1}"
+      - "SVC_NAME=couchdb-2.local"
+      - "COUCHDB_SYNC_ADMINS_NODE=${COUCHDB_SYNC_ADMINS_NODE:-couchdb-1.local}"
 networks:
   cht-net:
      driver: overlay
@@ -237,15 +237,15 @@ Finally, we'll match Node 3  up with the others by running this code:
 
 ```shell
 cd /home/ubuntu/cht/
-curl -s -o ./docker-compose.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.0.1/docker-compose/cht-couchdb.yml
+curl -s -o ./docker-compose.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.1.0/docker-compose/cht-couchdb.yml
 cat > /home/ubuntu/cht/cluster-overrides.yml << EOF
 version: '3.9'
 services:
   couchdb:
-    container_name: couchdb.3
+    container_name: couchdb-3.local
     environment:
-      - "SVC_NAME=couchdb.3"
-      - "COUCHDB_SYNC_ADMINS_NODE=${COUCHDB_SYNC_ADMINS_NODE:-couchdb.1}"
+      - "SVC_NAME=couchdb-3.local"
+      - "COUCHDB_SYNC_ADMINS_NODE=${COUCHDB_SYNC_ADMINS_NODE:-couchdb-1.local}"
 networks:
   cht-net:
      driver: overlay

--- a/content/en/apps/guides/hosting/4.x/self-hosting-single-node.md
+++ b/content/en/apps/guides/hosting/4.x/self-hosting-single-node.md
@@ -25,8 +25,8 @@ The following 3 `curl` commands download CHT version `4.0.1` compose files, whic
 
 ```shell
 cd /home/ubuntu/cht/
-curl -s -o ./compose/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.0.1/docker-compose/cht-core.yml
-curl -s -o ./compose/cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.0.1/docker-compose/cht-couchdb.yml
+curl -s -o ./compose/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.1.0/docker-compose/cht-core.yml
+curl -s -o ./compose/cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.1.0/docker-compose/cht-couchdb.yml
 curl -s -o ./upgrade-service/docker-compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
 ```
 

--- a/content/en/apps/tutorials/local-setup.md
+++ b/content/en/apps/tutorials/local-setup.md
@@ -57,7 +57,7 @@ Open your terminal and run these commands which will create a directory, downloa
 ```shell
 mkdir -p ~/cht-local-setup/couch-data/ && mkdir -p ~/cht-local-setup/core-couch/ && mkdir -p ~/cht-local-setup/upgrade/
 cd ~/cht-local-setup
-curl -s -o ./core-couch/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.0.1/docker-compose/cht-core.yml && curl -s -o ./core-couch/cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.0.1/docker-compose/cht-couchdb.yml && curl -s -o ./upgrade/docker-compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
+curl -s -o ./core-couch/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.1.0/docker-compose/cht-core.yml && curl -s -o ./core-couch/cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.1.0/docker-compose/cht-couchdb.yml && curl -s -o ./upgrade/docker-compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
 cat > ${HOME}/cht-local-setup/upgrade/.env << EOF
 DOCKER_CONFIG_PATH=${HOME}/cht-local-setup/core-couch/
 COUCHDB_DATA=${HOME}/cht-local-setup/data/couch-data 


### PR DESCRIPTION
This PR:
* bumps all `curl` requests fetching docker compose files to use `4.1.0` instead of `4.0.1`
* fixes a misnamed `yml` file for the override in the 2nd couchdb node
* renames `couchdb.x` -> `couchdb-x.local` per #medic/cht-core/issues/7962 