### PR TITLE
make docker-compose.yml default , remove all but first ref of  docker-compose-developer-3.x-only.yml

### DIFF
--- a/content/en/apps/guides/hosting/3.x/self-hosting.md
+++ b/content/en/apps/guides/hosting/3.x/self-hosting.md
@@ -18,7 +18,7 @@ Whether run on bare-metal or in a cloud provider, the Community Health Toolkit (
 
 The CHT containers are installed using [docker compose](https://docs.docker.com/compose/reference/overview/) so that you can run multiple containers  as a single service.
 
-Start by choosing the location where you would like to save your compose configuration file.  Then create the `docker-compose-developer-3.x-only.yml` file by `cd`ing into the correct directory and running:
+Start by choosing the location where you would like to save your compose configuration file.  Then create the `docker-compose.yml` file by `cd`ing into the correct directory and running:
 
 ```bash
 curl -s -o docker-compose.yml https://raw.githubusercontent.com/medic/cht-core/master/scripts/docker-helper/docker-compose-developer-3.x-only.yml
@@ -29,16 +29,16 @@ The install requires an admin password that it will configure in the database. Y
 
 `export DOCKER_COUCHDB_ADMIN_PASSWORD=myAwesomeCHTAdminPassword`
 
-You can then run `docker-compose` in the folder where you put your compose  `docker-compose-developer-3.x-only.yml` file. To start, run it interactively to see all the logs on screen and be able to stop the containers with `ctrl` + `c`:
+You can then run `docker-compose` in the folder where you put your compose  `docker-compose.yml` file. To start, run it interactively to see all the logs on screen and be able to stop the containers with `ctrl` + `c`:
 
 ```bash
-sudo docker-compose -f docker-compose-developer-3.x-only.yml up 
+sudo docker-compose up 
 ```
 
 If there are no errors, stop the containers with `ctrl` + `c` and then run it detached with `-d`:
 
 ```bash
-sudo docker-compose -f docker-compose-developer-3.x-only.yml up -d
+sudo docker-compose up -d
 ```
 
 Note In certain shells, `docker-compose` may not interpolate the admin password that was exported in `DOCKER_COUCHDB_ADMIN_PASSWORD`. Check if this is the case by searching the logs in the medic-os dockers instance. If the `docker logs medic-os` command below returns a user and password, then the export above failed, and you should use this user and password to complete the installation:
@@ -75,10 +75,10 @@ If some  instructions were missed and there's a broken CHT deployment, use the c
 1. Remove containers: `docker rm medic-os && docker rm haproxy`
 1. Clean data volume:`docker volume rm medic-data`
 
-    Note: Running `docker-compose -f docker-compose-developer-3.x-only.yml down -v`  would do all the above 3 steps
+    Note: Running `docker-compose down -v`  would do all the above 3 steps
 1. Prune system: `docker system prune`
 
-After following the above commands, you can re-run docker-compose up and create a clean install:  `docker-compose -f docker-compose-developer-3.x-only.yml up -d`
+After following the above commands, you can re-run docker-compose up and create a clean install:  `docker-compose up -d`
 
 ### Port Conflicts
 
@@ -108,11 +108,11 @@ services:
 
 Turn off and remove all existing containers that were started:
 
- `sudo docker-compose -f /path/to/docker-compose-developer-3.x-only.yml down`
+ `sudo docker-compose down`
 
 Bring Up the containers in detached mode with the new forwarded ports.
 
- `sudo docker-compose -f /path/to/docker-compose-developer-3.x-only.yml up -d`
+ `sudo docker-compose up -d`
 
 Note: You can  substitute 8080, 444 with whichever ports are free on your host. You would now visit https://localhost:444 to visit your project.
 


### PR DESCRIPTION
This PR fixes the repetitive user of `docker-compose-developer-3.x-only.yml` and standardizes on `docker-compose.yml`

The  `docker-compose-developer-3.x-only.yml`  file was created when we released CHT 4.0.0 and we didn't want to confuse people.  However, the instructions as is don't work as the first `curl` uses the URL of the `3.x-only` file but saves it  `docker-compose.yml`.  By removing the long name all the commands are simplified. 