### PR TITLE
Table format for core competencies

### DIFF
--- a/content/en/contribute/medic/product-core-competencies/_index.md
+++ b/content/en/contribute/medic/product-core-competencies/_index.md
@@ -6,17 +6,10 @@ description: >
   These core competencies are intended to guide Product Teammates in how everyone shows up for each other every day. They are to be used in hiring new teammates, teammate feedback, and regular manager check ins. 
 ---
 
-## Reliable
-Gets things done when people expect them without prompting.
-
-## Team Player
-Acts in the best interest of the team and actively looks for ways to help the team. Makes time to support teammates to be successful.
-
-## Growth Mindset
-Always seeking to improve. Open minded, teachable, and coachable.
-
-## Proactive
-Sees things that need doing and takes action to keep things moving and make the team successful.
-
-## Effective Communicator
-Communicates regularly, openly, and effectively using the appropriate channels.
+| Core Competency | Description |
+| ----------------| ----------- |
+| **Reliable** | Gets things done when people expect them without prompting. |
+| **Team Player** | Acts in the best interest of the team and actively looks for ways to help the team. Makes time to support teammates to be successful. |
+| **Growth Mindset** | Always seeking to improve. Open minded, teachable, and coachable. |
+| **Proactive** | Sees things that need doing and takes action to keep things moving and make the team successful. |
+| **Effective Communicator** | Communicates regularly, openly, and effectively using the appropriate channels. |


### PR DESCRIPTION
The basic heading+description format was fine, but the Hugo template adds an H2 "Feedback" item to the end which at first is a bit confusing as it looks like it's a 6th core competency of "feedback". This format change makes it much more clear what on the page is actually for what.

Here are screenshots showing the formatting confusion and the proposed visual change to avoid it:
![image](https://user-images.githubusercontent.com/1485206/222728998-a639f17e-4ac3-46cb-b6bb-67871f9c0638.png)
![image](https://user-images.githubusercontent.com/1485206/222729186-2ee70883-22d9-4559-8fc2-9de6e6399d36.png)
