### PR TITLE
add steps to use certbot with CHT

### DIFF
--- a/content/en/apps/guides/hosting/requirements.md
+++ b/content/en/apps/guides/hosting/requirements.md
@@ -20,19 +20,24 @@ These requirements apply to both 3.x and 4.x CHT hosting
 
 Hosting a CHT instance in a cloud provider like AWS or on bare-metal requires you have sufficient hardware specifications, Docker and Docker Compose installed and other infrastructure requirements met.
 
+## Infrastructure Requirements
+
+- A static IP
+- A DNS Entry pointing to the IP
+- TLS certificates
+
 ## Hardware Requirements
 
 - 4 GiB RAM
 - 2 CPU/vCPU
-- 8 GB Hard Disk (SSD prefered)
-- SSL certificates ( To be able to use the CHT app on mobile)
+- 8 GB Hard Disk (SSD preferred)
 - Root Access 
 
 Depending on the scale of your operation these may need to be adjusted. Be sure to monitor disk usage so that the 8 GB can be increased as needed.
 
 ##  Docker
 
-Install both `docker` and `docker-compose` to run the two `medic-os` and `haproxy` containers.
+Install both `docker` and `docker-compose` to run CHT and realted containers.
 
 {{% alert title="Note" %}}
 Skip this step if you're following the  [EC2 guide 3.x]({{< relref "apps/guides/hosting/3.x/ec2-setup-guide#create-and-configure-ec2-instance" >}}) as `docker` and `docker-compose` are automatically installed when following the setup scripts. 

--- a/content/en/apps/guides/hosting/requirements.md
+++ b/content/en/apps/guides/hosting/requirements.md
@@ -37,7 +37,7 @@ Depending on the scale of your operation these may need to be adjusted. Be sure 
 
 ##  Docker
 
-Install both `docker` and `docker-compose` to run CHT and realted containers.
+Install both `docker` and `docker-compose` to run CHT and related containers.
 
 {{% alert title="Note" %}}
 Skip this step if you're following the  [EC2 guide 3.x]({{< relref "apps/guides/hosting/3.x/ec2-setup-guide#create-and-configure-ec2-instance" >}}) as `docker` and `docker-compose` are automatically installed when following the setup scripts. 


### PR DESCRIPTION
This PR:
* Breaks up the [existing TLS page](https://docs.communityhealthtoolkit.org/apps/guides/hosting/4.x/adding-tls-certificates/) into two parts: one for pre-existing certs and certbot certs via let's encrypt
* updates a bit of the existing [requirements page](https://docs.communityhealthtoolkit.org/apps/guides/hosting/requirements/) to be more up to date.

Per #medic/cht-core/issues/8099