### PR TITLE
chore(#921): Clarify the release process

### DIFF
--- a/content/en/apps/guides/updates/preparing-for-4.md
+++ b/content/en/apps/guides/updates/preparing-for-4.md
@@ -167,7 +167,7 @@ CHT 4.0 [upgrades the version of Enketo](https://github.com/medic/cht-core/pull/
 
 You can also manually test your forms on a non-prod CHT instance. It is possible to test your forms against the new Enekto changes without having to uplift your non-prod CHT instance to the new 4.0 architecture.
 
-An easy way of doing this is to use the [CHT Docker Helper]({{< relref "apps/guides/hosting/3.x/app-developer#cht-docker-helper" >}}) to deploy a 3.x CHT instance. After you have your dev instance up and running, use [Horticulturalist](https://github.com/medic/horticulturalist) to upgrade to the `3.17.0-FR-enketo-upgrade` [feature release]({{< relref "core/releases/feature_releases" >}}):
+An easy way of doing this is to use the [CHT Docker Helper]({{< relref "apps/guides/hosting/3.x/app-developer#cht-docker-helper" >}}) to deploy a 3.x CHT instance. After you have your dev instance up and running, use [Horticulturalist](https://github.com/medic/horticulturalist) to upgrade to the `3.17.0-FR-enketo-upgrade` [feature release]({{< relref "contribute/code/releasing/feature_releases" >}}):
 
 ```shell
 COUCH_URL=https://medic:password@*your-my.local.ip.co-address*:8443/medic horti --local --install=3.17.0-FR-enketo-upgrade-beta.1

--- a/content/en/contribute/code/releasing.md
+++ b/content/en/contribute/code/releasing.md
@@ -10,7 +10,7 @@ aliases: >
 
 ## CHT Core
 
-A release is a set of changes that is planned to be used by at least one implementation that uses the CHT.
+A release is a set of code changes bundled together, ideally with at least one deployment of CHT apps ready to make use of it.
 
 ### Building & Releasing CHT Core Changes
 

--- a/content/en/contribute/code/releasing.md
+++ b/content/en/contribute/code/releasing.md
@@ -29,7 +29,7 @@ The high-level steps for a release are as follows:
 ### Release Manager
 The overall coordination and operation of the release process are the responsibility of the release manager.
 
-The release manager must perform several tasks for new release, such as coordinating with team members and following all the steps in the [release issue process](https://github.com/medic/cht-core/issues/new/choose), some of them being manual. The release manager must have adequate permissions to the repositories where the release is made.
+The release manager must perform several tasks for a new release, such as coordinating with team members and following all the steps in the [release issue process](https://github.com/medic/cht-core/issues/new/choose), some of them being manual. The release manager must have adequate permissions to the repositories where the release is made.
 
 ### Major/Minor/Patch Release
 {{% alert title="Note" %}} The following classification is defined by the [Semantic Versioning 2.0.0](https://semver.org). {{% /alert %}}

--- a/content/en/contribute/code/releasing.md
+++ b/content/en/contribute/code/releasing.md
@@ -35,9 +35,9 @@ The release manager must perform several tasks for new release, such as coordina
 {{% alert title="Note" %}} The following classification is defined by the [Semantic Versioning 2.0.0](https://semver.org). {{% /alert %}}
 
 Given a version number `MAJOR.MINOR.PATCH`, increment the:
-* `MAJOR` version when you make incompatible API changes
-* `MINOR` version when you add functionality in a backward-compatible manner
-* `PATCH` version when you make backward-compatible bug fixes
+* `MAJOR` version the release adds incompatible API changes
+* `MINOR` version the release adds functionality in a backward-compatible manner
+* `PATCH` version the release adds backward-compatible bug fixes
 
 ## CHT Conf
 

--- a/content/en/contribute/code/releasing.md
+++ b/content/en/contribute/code/releasing.md
@@ -21,7 +21,7 @@ The high-level process for a release is as follows:
 * Tickets are added to the [Product Team Activities board](https://github.com/orgs/medic/projects/134/views/3) for what's being built.
 * A [release manager](#release-manager) is assigned from the team.
 * The release manager [creates an issue](https://github.com/medic/cht-core/issues/new/choose) for either a [Major/Minor or Patch](#major-minor-patch-release) release issue template and follows the process.
-* Change is built by a developer together with [quality assistance]({{% ref "/contribute/medic/product-development-process/quality-assistance" %}}).
+* Code is built by a developer together with [quality assistance]({{% ref "/contribute/medic/product-development-process/quality-assistance" %}}).
 * [Code is reviewed]({{% ref "/contribute/code/workflow#code-reviews" %}}).
 * Code is merged.
 * Code is released.

--- a/content/en/contribute/code/releasing.md
+++ b/content/en/contribute/code/releasing.md
@@ -35,9 +35,9 @@ The release manager must perform several tasks for new release, such as coordina
 {{% alert title="Note" %}} The following classification is defined by the [Semantic Versioning 2.0.0](https://semver.org). {{% /alert %}}
 
 Given a version number `MAJOR.MINOR.PATCH`, increment the:
-* `MAJOR` version the release adds incompatible API changes
-* `MINOR` version the release adds functionality in a backward-compatible manner
-* `PATCH` version the release adds backward-compatible bug fixes
+* `MAJOR` version when the release adds incompatible API changes
+* `MINOR` version when the release adds functionality in a backward-compatible manner
+* `PATCH` version when the release adds backward-compatible bug fixes
 
 ## CHT Conf
 

--- a/content/en/contribute/code/releasing.md
+++ b/content/en/contribute/code/releasing.md
@@ -10,7 +10,34 @@ aliases: >
 
 ## CHT Core
 
-[Create an issue](https://github.com/medic/cht-core/issues/new/choose) for either a Major/Minor or Patch release issue template and assign it to the release manager to follow the process.
+A release is a set of changes that is planned to be used by at least one implementation that uses the CHT.
+
+### Release Process
+
+The high-level process for a release is as follows:
+
+* The team sees an opportunity they want to go after. The opportunity addresses a need of at least one implementation that uses the CHT and will be used by that implementation after the release.
+* The team agrees on a solution for it.
+* Tickets are added to the [Product Team Activities board](https://github.com/orgs/medic/projects/134/views/3) for what's being built.
+* A [release manager](#release-manager) is assigned from the team.
+* The release manager [creates an issue](https://github.com/medic/cht-core/issues/new/choose) for either a [Major/Minor or Patch](#major-minor-patch-release) release issue template and follows the process.
+* Change is built by a developer together with [quality assistance]({{% ref "/contribute/medic/product-development-process/quality-assistance" %}}).
+* [Code is reviewed]({{% ref "/contribute/code/workflow#code-reviews" %}}).
+* Code is merged.
+* Code is released.
+
+### Release Manager
+The overall coordination and operation of the release process are the responsibility of the release manager.
+
+The release manager must perform several tasks for new release, such as coordinating with team members and following all the steps in the [release issue process](https://github.com/medic/cht-core/issues/new/choose), some of them being manual. The release manager must have adequate permissions to the repositories where the release is made.
+
+### Major/Minor/Patch Release
+{{% alert title="Note" %}} The following classification is defined by the [Semantic Versioning 2.0.0](https://semver.org). {{% /alert %}}
+
+Given a version number `MAJOR.MINOR.PATCH`, increment the:
+* `MAJOR` version when you make incompatible API changes
+* `MINOR` version when you add functionality in a backward-compatible manner
+* `PATCH` version when you make backward-compatible bug fixes
 
 ## CHT Conf
 

--- a/content/en/contribute/code/releasing.md
+++ b/content/en/contribute/code/releasing.md
@@ -12,9 +12,9 @@ aliases: >
 
 A release is a set of changes that is planned to be used by at least one implementation that uses the CHT.
 
-### Release Process
+### Building & Releasing CHT Core Changes
 
-The high-level process for a release is as follows:
+The high-level steps for a release are as follows:
 
 * The team sees an opportunity they want to go after. The opportunity addresses a need of at least one implementation that uses the CHT and will be used by that implementation after the release.
 * The team agrees on a solution for it.

--- a/content/en/contribute/code/releasing.md
+++ b/content/en/contribute/code/releasing.md
@@ -16,7 +16,7 @@ A release is a set of changes that is planned to be used by at least one impleme
 
 The high-level steps for a release are as follows:
 
-* The team sees an opportunity they want to go after. The opportunity addresses a need of at least one implementation that uses the CHT and will be used by that implementation after the release.
+* The team sees an opportunity they want to go after. The opportunity addresses a need of at least one CHT app deployment and will be used by that deployment after the release.
 * The team agrees on a solution for it.
 * Tickets are added to the [Product Team Activities board](https://github.com/orgs/medic/projects/134/views/3) for what's being built.
 * A [release manager](#release-manager) is assigned from the team.
@@ -35,9 +35,9 @@ The release manager must perform several tasks for a new release, such as coordi
 {{% alert title="Note" %}} The following classification is defined by the [Semantic Versioning 2.0.0](https://semver.org). {{% /alert %}}
 
 Given a version number `MAJOR.MINOR.PATCH`, increment the:
-* `MAJOR` version when the release adds incompatible API changes
-* `MINOR` version when the release adds functionality in a backward-compatible manner
-* `PATCH` version when the release adds backward-compatible bug fixes
+* `MAJOR` version when the release adds incompatible changes, e.g. when the apps built on top of the CHT require manual intervention to work as expected.
+* `MINOR` version when the release adds functionality in a backward-compatible manner.
+* `PATCH` version when the release adds backward-compatible bug fixes.
 
 ## CHT Conf
 

--- a/content/en/contribute/code/releasing.md
+++ b/content/en/contribute/code/releasing.md
@@ -16,11 +16,11 @@ A release is a set of code changes bundled together, ideally with at least one d
 
 The high-level steps for a release are as follows:
 
-* The team sees an opportunity they want to go after. The opportunity addresses a need of at least one CHT app deployment and will be used by that deployment after the release.
-* The team agrees on a solution for it.
+* The [Focused Working Group]({{% ref "/contribute/medic/product-development-process/focused-groups" %}}) sees an opportunity they want to go after. The opportunity addresses a need of at least one CHT app deployment and will be used by that deployment after the release.
+* The Focused Working Group agrees on a solution for it.
 * Tickets are added to the [Product Team Activities board](https://github.com/orgs/medic/projects/134/views/3) for what's being built.
 * A [release manager](#release-manager) is assigned from the team.
-* The release manager [creates an issue](https://github.com/medic/cht-core/issues/new/choose) for either a [Major/Minor or Patch](#major-minor-patch-release) release issue template and follows the process.
+* The release manager [creates an issue](https://github.com/medic/cht-core/issues/new/choose) for either a [Major/Minor or Patch](#majorminorpatch-release) release issue template and follows the process.
 * Code is built by a developer together with [quality assistance]({{% ref "/contribute/medic/product-development-process/quality-assistance" %}}).
 * [Code is reviewed]({{% ref "/contribute/code/workflow#code-reviews" %}}).
 * Code is merged.

--- a/content/en/contribute/code/releasing/_index.md
+++ b/content/en/contribute/code/releasing/_index.md
@@ -20,7 +20,7 @@ The high-level steps for a release are as follows:
 * The Focused Working Group agrees on a solution for it.
 * Tickets are added to the [Product Team Activities board](https://github.com/orgs/medic/projects/134/views/3) for what's being built.
 * A [release manager](#release-manager) is assigned from the team.
-* The release manager [creates an issue](https://github.com/medic/cht-core/issues/new/choose) for either a [Major/Minor or Patch](#majorminorpatch-release) release issue template and follows the process.
+* The release manager [creates an issue](https://github.com/medic/cht-core/issues/new/choose) for either a [Major/Minor or Patch](#majorminorpatch-release) release and follows the process outlined in the issue template.
 * Code is built by a developer together with [quality assistance]({{% ref "/contribute/medic/product-development-process/quality-assistance" %}}).
 * [Code is reviewed]({{% ref "/contribute/code/workflow#code-reviews" %}}).
 * Code is merged.

--- a/content/en/contribute/code/releasing/_index.md
+++ b/content/en/contribute/code/releasing/_index.md
@@ -39,6 +39,8 @@ Given a version number `MAJOR.MINOR.PATCH`, increment the:
 * `MINOR` version when the release adds functionality in a backward-compatible manner.
 * `PATCH` version when the release adds backward-compatible bug fixes.
 
+`MAJOR` releases represent the biggest scale of code change and their roll out effort is high, as they likely require time and effort to set up or configure. As a consequence, they are the least frequent of the three release types.
+
 {{% alert title="Info" %}} You can find the versions currently supported, dependencies, and release notes for the CHT Core 
  [on the Releases page]({{% ref "core/releases" %}}). {{% /alert %}}
 

--- a/content/en/contribute/code/releasing/_index.md
+++ b/content/en/contribute/code/releasing/_index.md
@@ -39,6 +39,9 @@ Given a version number `MAJOR.MINOR.PATCH`, increment the:
 * `MINOR` version when the release adds functionality in a backward-compatible manner.
 * `PATCH` version when the release adds backward-compatible bug fixes.
 
+{{% alert title="Info" %}} You can find the versions currently supported, dependencies, and release notes for the CHT Core 
+ [on the Releases page]({{% ref "core/releases" %}}). {{% /alert %}}
+
 ## CHT Conf
 
 Follow the [instructions in the readme](https://github.com/medic/cht-conf/#user-content-releasing).

--- a/content/en/contribute/code/releasing/feature_releases.md
+++ b/content/en/contribute/code/releasing/feature_releases.md
@@ -7,6 +7,7 @@ description: >
 relatedContent: >
     core/releases
     contribute#are-you-a-partner-wondering-how-issues-are-prioritized
+    core/releases/feature_releases/
     
 ---
 

--- a/content/en/contribute/code/releasing/feature_releases.md
+++ b/content/en/contribute/code/releasing/feature_releases.md
@@ -4,10 +4,11 @@ linkTitle: "Feature Releases"
 weight: 1
 description: >
     Feature Releases for the CHT Core Framework
+aliases:
+  -    /core/releases/feature_releases/
 relatedContent: >
     core/releases
     contribute#are-you-a-partner-wondering-how-issues-are-prioritized
-    core/releases/feature_releases/
     
 ---
 

--- a/content/en/contribute/code/releasing/feature_releases.md
+++ b/content/en/contribute/code/releasing/feature_releases.md
@@ -1,7 +1,7 @@
 ---
 title: "Feature Releases"
 linkTitle: "Feature Releases"
-weight: 2
+weight: 1
 description: >
     Feature Releases for the CHT Core Framework
 relatedContent: >
@@ -56,4 +56,4 @@ On subsequent upgrades to the later beta's of the FR, you will be able to more e
 
 ## Upgrades to release
 
-Once the feature is ready for widespread use, it will be included in a regular CHT release. Projects using the feature version can be upgraded as soon as practical to get back on to a fully supported release.
+Once the feature is ready for widespread use, it will be included in a regular [CHT release]({{% ref "/contribute/code/releasing" %}}). Projects using the feature version can be upgraded as soon as practical to get back on to a fully supported release.


### PR DESCRIPTION
Adds clarifications about the release process:

- When a release is made 
- Release process steps
- Responsibilities of the release manager
- Clarifications on `minor`/`major`/`patch` releases

Closes #921 