### PR TITLE
Report's subject ID cannot be set by `doc.patient_uuid`

### DIFF
--- a/content/en/core/overview/db-schema.md
+++ b/content/en/core/overview/db-schema.md
@@ -178,7 +178,7 @@ All reports:
  - Store the form's identifier in the `form` field
  - May have a `contact` property, which is a minified version of the report author's contact and its hierarchy (see above)
 
-Reports can and should be linked to a contact when appropriate. The report's contact (sometimes called the report's subject) can be a person or place. The link between report and contact is established through one of the following properties one report:
+Reports can and should be linked to a contact when possible. The report's associated contact (sometimes called the report's subject) can be either a person or place. The link between report and contact is established by defining one of the following properties within the report:
 
  1. A person shortcode or uuid at `doc.fields.patient_id`, `doc.fields.patient_uuid`, or `doc.patient_id`
  2. A place shortcode or uuid at `doc.fields.place_id` or `doc.place_id`.

--- a/content/en/core/overview/db-schema.md
+++ b/content/en/core/overview/db-schema.md
@@ -178,13 +178,10 @@ All reports:
  - Store the form's identifier in the `form` field
  - May have a `contact` property, which is a minified version of the report author's contact and its hierarchy (see above)
 
-Reports can be about people or places.
+Reports can and should be linked to a contact when appropriate. The report's contact (sometimes called the report's subject) can be a person or place. The link between report and contact is established through one of the following properties one report:
 
-Reports about people should have one or more of:
- - A patient shortcode, found at `doc.patient_id` or `doc.fields.patient_id`
- - A patient record's `_id`, found at `doc.patient_uuid` or `doc.fields.patient_uuid`, as well as potientially in the same locations as the shortcode
-
-Reports about places should have a place's shortcode, found at `doc.place_id` or `doc.fields.place_id`.
+ 1. A person shortcode or uuid at `doc.fields.patient_id`, `doc.fields.patient_uuid`, or `doc.patient_id`
+ 2. A place shortcode or uuid at `doc.fields.place_id` or `doc.place_id`.
 
 Additionally, SMS reports:
  - Have an `sms_message` property which contains, among other things, the raw SMS


### PR DESCRIPTION
A report's subject can only be defined via `doc.fields.patient_uuid` never `doc.patient_uuid`.

https://github.com/medic/cht-core/blob/8f328d40b21dd95a6f24606e19c607c75e8dc41d/shared-libs/lineage/src/utils.js#L21 https://github.com/medic/cht-core/blob/69b478371091c0fa3cac00003e04af052050346d/ddocs/medic-db/medic/views/docs_by_replication_key/map.js#L32

It is used here - but that's likely a bug? 
https://github.com/medic/cht-core/blob/899e30df5fc6b7c52c99893609887ae714c87cd0/admin/src/js/services/message-queue.js#L324

I suspect we should not encourage users to set multiple subjects because cht-core appears non-deterministic on which it looks at first.