### PR TITLE
fix: remove deprecated configuration option

### DIFF
--- a/content/en/apps/reference/tasks.md
+++ b/content/en/apps/reference/tasks.md
@@ -106,7 +106,7 @@ module.exports = [
   // PNC TASK 1: If a home delivery, needs clinic tasks
   {
     icon: 'mother-child',
-    title: [ { locale:'en', content:'Postnatal visit needed' } ],
+    title: 'task.postnatal_followup.title',
     appliesTo: 'reports',
     appliesToType: [ 'D', 'delivery' ],
     appliesIf: function(c, r) {


### PR DESCRIPTION
As per https://forum.communityhealthtoolkit.org/t/task-title-with-an-array-of-translations/2671/2