### PR TITLE
Switches Analytics from UA to GA4

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -46,7 +46,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-168418637-1"
+id = "G-362515267"
 
 # Language configuration
 


### PR DESCRIPTION
For #1058

Uses the new Analytics ID and format, as per docs: https://www.docsy.dev/docs/adding-content/feedback/