### PR TITLE
fix: Exclude twitter link from check

### DIFF
--- a/.github/scripts/muffet.sh
+++ b/.github/scripts/muffet.sh
@@ -36,5 +36,6 @@ muffet http://localhost:1313 \
   --exclude "http[s]*://.*udemy.com.*" \
   --exclude "http[s]*://.*notion.so.*" \
   --exclude "http[s]*://.*medium.com.*" \
+  --exclude "http[s]*://.*twitter.com.*" \
   --exclude "https://fhir.org/" \
   --exclude "https://docs.google.com/spreadsheets/d/12345ABCDEF/.*"


### PR DESCRIPTION
The [build](https://github.com/medic/cht-docs/commit/98aa1459e6879b7fc3929bf8d64f6a1c9ed73aec/checks) failed for 3 consecutive days, due to twitter sending `too many redirections` error.