### PR TITLE
fix(na) remove extra mermaid conf fix numbering in watchdog

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -209,11 +209,3 @@ RelPermalink= "communityhealthtoolkit.org"
  [[related.indices]]
     name = "keywords"
     weight = 1
-
-[params.mermaid]
-theme = "neutral"
-
-[params.mermaid.flowchart]
-nodeSpacing = 30
-rankSpacing = 60
-curve = "linear"

--- a/content/en/apps/guides/hosting/monitoring/integration.md
+++ b/content/en/apps/guides/hosting/monitoring/integration.md
@@ -66,10 +66,10 @@ By reading this guide you should not only be able to set up cAdvisor, but also b
 
 While this is a specific example for cAdvisor, these same steps will be taken to extend Watchdog for other metrics:
 
-3. CHT Core: [Create both cAdvisor and Caddy Docker Compose files]({{< relref "#cadvisor-compose-file" >}})
-4. CHT Core: [Start the Caddy and a cAdvisor containers along with the CHT Core]({{< relref "#start-cadvisor-caddy-and-cht-core-with-docker" >}})
-1. CHT Watchdog: [Adding new scrape and compose configs]({{< relref "#scrape-config" >}})
-2. CHT Watchdog: [Restart the Prometheus and Grafana server to include the new scrape config mounts]({{< relref "#load-new-compose-files-with-existing-ones" >}})
+1. CHT Core: [Create both cAdvisor and Caddy Docker Compose files]({{< relref "#cadvisor-compose-file" >}})
+2. CHT Core: [Start the Caddy and a cAdvisor containers along with the CHT Core]({{< relref "#start-cadvisor-caddy-and-cht-core-with-docker" >}})
+3. CHT Watchdog: [Adding new scrape and compose configs]({{< relref "#scrape-config" >}})
+4. CHT Watchdog: [Restart the Prometheus and Grafana server to include the new scrape config mounts]({{< relref "#load-new-compose-files-with-existing-ones" >}})
 5. CHT Watchdog: [Importing an exising cAdvisor dashboard from `grafana.com`]({{< relref "#on-cht-watchdog-import-grafana-dashboard" >}})
 
 After completing these steps, we now have Docker metrics we can alert on:


### PR DESCRIPTION
This PR:
* removes the extra mermaid config
* fixes the numbering on the CHT Watchdog page

The [extra mermaid config](https://github.com/medic/cht-docs/blob/58e3ced0a9230f71adf3f86430fe7b3ae31dc1e4/config.toml#L213) removes the colors and tightens up the charts.  Top is with this PR, bottom is [what is live now](https://docs.communityhealthtoolkit.org/apps/guides/hosting/monitoring/integration/#additional-flows):

![image](https://github.com/medic/cht-docs/assets/8253488/09b077a4-62b3-4437-824b-4671cd43f16c)

[The numbering that is off](https://docs.communityhealthtoolkit.org/apps/guides/hosting/monitoring/integration/#steps-to-new-integrations) that this PR fixes:

![image](https://github.com/medic/cht-docs/assets/8253488/efb76a56-598d-4e13-9d22-84e14e804891)

