### PR TITLE
fix(#1106) Muffet DNS Issues & CI Names

### DIFF
--- a/.github/scripts/set_dns.sh
+++ b/.github/scripts/set_dns.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# At one point we had issues with the DNS server that GH CI Runners use,
+# so this script was written to change Muffet to use Quad9. While Quad9 presumably
+# will be a bit slower than local DNS to GH CI, it shouldn't matter as Muffet
+# is run once a day and is not speed sensitive.
+#
+# More Info:
+#  - Issue: local-ip.medicmobile.org doesn't resolve on GH runners, causes
+#           link check errors (https://github.com/medic/cht-docs/issues/1106)
+#  - Quad9: 9.9.9.9 DNS Server being used (https://quad9.net)
+
+echo
+echo "------------------------"
+echo "calling: resolvectl dns eth0"
+resolvectl dns eth0
+
+echo
+echo "------------------------"
+echo "calling: dig local-ip.medicmobile.org  +short"
+dig local-ip.medicmobile.org +short
+
+echo
+echo "------------------------"
+echo "calling: sudo resolvectl dns eth0 9.9.9.9 149.112.112.112"
+sudo resolvectl dns eth0 9.9.9.9 149.112.112.112
+
+echo
+echo "------------------------"
+echo "calling: resolvectl dns eth0"
+resolvectl dns eth0
+
+echo
+echo "------------------------"
+echo "calling: dig local-ip.medicmobile.org  +short"
+dig local-ip.medicmobile.org +short

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -20,44 +20,48 @@ jobs:
     timeout-minutes: 15
     steps:
 
-      - name: All Branches - Git checkout
+      - name: Git checkout cht-docs repos
         uses: actions/checkout@v2
         with:
           fetch-depth: 0         # Fetch all history for .GitInfo and .Lastmod
 
-      - name: All Branches - Install hugo extended v0.101.0
+      - name: Install hugo extended v0.101.0
         uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: "0.101.0"
           extended: true
 
-      - name: All Branches - Install Node 12.x
+      - name: Install Node 12.x
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
 
-      - name: All Branches - Install npm modules for Hugo
+      - name: Install npm modules for Hugo
         run: npm install
 
-      - name: All Branches - Install Go v1.18
+      - name: Install Go v1.18
         uses: actions/setup-go@v2
         with:
           go-version: '1.18'
 
-      - name: All Branches - Install Muffet v1.5.7
+      - name: Install Muffet v1.5.7
         run: GO111MODULE=on go install github.com/raviqqe/muffet@v1.5.7
 
       # run in background so CI doesn't hang waiting for "ctrl + c".  Sleep ensures server is ready in next step
-      - name: All Branches - Serve Hugo site
+      - name: Serve Hugo site
         run: |
           hugo server&
           sleep 30
 
-      - name: All Branches - Run Muffet link checker
+      - name: Set DNS to 9.9.9.9
+        shell: bash
+        run: ./.github/scripts/set_dns.sh
+
+      - name: Run Muffet link checker
         shell: bash
         run: ./.github/scripts/muffet.sh
 
-      - name: Main Branch Only - Report errors to Slack, if any
+      - name: Report errors to Slack, if any
         if: ${{ github.ref == 'refs/heads/main' && failure() }}
         uses: rtCamp/action-slack-notify@v2.0.2
         env:


### PR DESCRIPTION
This PR:
* Adds a new `[set_dns.sh](https://github.com/medic/cht-docs/compare/1106-fix-muffet-dns-issues?expand=1#diff-41bc4f19b66c95e56aa6a4eb3e44559e4f15369d246de7e9c3125a6c681ebfa5)`  script which sets GH CI runner DNS to `9.9.9.9`
* Updates CI to call the new `set_dns.sh` script
* Updates runner names to no longer have "All Branches -" and "Main only" as this script is always called on `main`, never on branches.
