### PR TITLE
#1122 Update documentation about absolute path

### DIFF
--- a/content/en/apps/guides/hosting/monitoring/setup.md
+++ b/content/en/apps/guides/hosting/monitoring/setup.md
@@ -54,6 +54,8 @@ These instructions have been tested against Ubuntu, but should work against any 
     echo "    username: medic"
     echo "    password: ${password}";echo
     ```
+   If you're using docker-compose v2.x, it doesn't support relative paths and you'll have to edit your `.env` file to update paths to absolute path.
+
    Note that in step 4 below you'll need the username and password which is printed after you run the above command.
 
 2. Edit the `cht-instances.yml` file to have the URLs of your CHT instances. You may include as many URLs of CHT instances as you like.


### PR DESCRIPTION
Update cht-watchdog setup guide about absolute path

For #1122 