### PR TITLE
fix(#1161): increase muffet timout from 10 to 35

### DIFF
--- a/.github/scripts/muffet.sh
+++ b/.github/scripts/muffet.sh
@@ -16,7 +16,7 @@
 
 muffet http://localhost:1313 \
   --buffer-size 50000 \
-  --timeout 10 \
+  --timeout 35 \
   --concurrency 2 \
   --ignore-fragments \
   --exclude ".*demo\.app\.medicmobile\.org.*" \


### PR DESCRIPTION
back in a8ea000cae45cc0b68b73a082b5beaad1de739a6 the `timeout` was decreased from `35` to `10` let's revert that in hopes of avoiding timeouts per #1161