### PR TITLE
Run link checker only on Sundays

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -9,8 +9,8 @@
 #    the default or base branch
 on:
   schedule:
-    # runs at 3:15am every day
-    - cron:  '15 3 * * *'
+    # runs at 3:15am every Sunday
+    - cron:  '15 3 * * 0'
 
 name: Test site for broken links
 jobs:


### PR DESCRIPTION
We get a lot of timeouts in the link checker.

I think because we check so often (every 24 hrs) we catch a lot of websites that are down. This greatly increases our false positives and reduces the trust in this link check script.  With all the noise in the channel, we end up ignoring the reports.

To reduce the noise and to hopefully reduce the false positives, I'm going to reduce the frequency of this script being run to 1/week instead of 1/day.