### PR TITLE
chore: Exclude Baserow demo from link checker

### DIFF
--- a/.github/scripts/muffet.sh
+++ b/.github/scripts/muffet.sh
@@ -40,4 +40,5 @@ muffet http://localhost:1313 \
   --exclude "https://tools.google.com.*" \
   --exclude "https://fhir.org/" \
   --exclude "https://docs.google.com/spreadsheets/d/12345ABCDEF/.*" \
+  --exclude "https://drive.google.com/file/d/1YPXoba9gVmD7SP-X88PpJIsIVGvY86_G/view?usp=share_link" \
   --exclude "https://doi.org/10.1080/02681102.2019.1667289"


### PR DESCRIPTION
Related to [this build fail](https://github.com/medic/cht-docs/commit/281eaa7084677c98ac531386dc225f28bf4039b4/checks). 