### PR TITLE
Add custom Sonar Quality Gate

### DIFF
--- a/content/en/contribute/code/static-analysis.md
+++ b/content/en/contribute/code/static-analysis.md
@@ -104,6 +104,19 @@ sonar.issue.ignore.multicriteria.e2.resourceKey=**/config.js
 
 Organization-level configuration must be made by an authorized user in the [SonarCloud UI](https://sonarcloud.io/projects). 
 
+##### Quality Gates
+
+Quality gates are used to define the criteria that must be met for a Sonar analysis to be considered "passing". The [`Sonar way` quality gate](https://docs.sonarcloud.io/improving/quality-gates/#how-quality-gates-are-defined) provides an example of a useful configuration. However, this gate config is not ideal for CHT code. Instead, the default quality gate for the `Medic` organization is the `CHT Way`.  It has the following [metrics](https://docs.sonarsource.com/sonarqube/latest/user-guide/metric-definitions/):
+
+
+| Metric                     | Operator        | Value |
+|----------------------------|-----------------|-------|
+| Duplicated Lines (%)       | is greater than | 3.0%  |
+| Issues                     | is greater than | 0     |
+| Reliability Rating         | is worse than   | A     |
+| Security Hotspots Reviewed | is less than    | 100%  |
+| Security Rating            | is worse than   | A     |
+
 ##### Quality Profiles
 
 The quality profiles are the lists of rules that will be applied for the various supported languages. By default, we use the `Sonar Way` quality profile for each language as it provides sensible defaults and is actively maintained receiving updates with new rules and bug fixes as they are added to Sonar.


### PR DESCRIPTION
This PR is for adding the documentation, but provides a good place for review/discussion of the planned changes (since they will need to be made manually in the SonarCloud webapp).

Basically, the problem with our current Sonar config is that it is allowing PRs to be merged when they still contain issues!  Any PR that fails our Quality Gate conditions (which currently just is the [`Sonar Way` gate](https://docs.sonarcloud.io/improving/quality-gates/#how-quality-gates-are-defined)) will be blocked from merging (or at least the CI will show as failing). However, if the Quality Gate does not fail, the CI will show as passing _even if Sonar identified issues in the code_.  

You can see this behavior in action on my [test branch](https://github.com/medic/cht-core/pull/8659/checks?check_run_id=17964614010).  The CI passes because the Gate passes even though you can see there are [9 Code Smells](https://sonarcloud.io/project/issues?id=medic_cht-core&pullRequest=8153&resolved=false&types=CODE_SMELL).  Several of these "code smells" are exactly the kind of thing we are trying to prevent with Sonar and the developer who submitted the PR would never know about them unless they click through to see the full Sonar status (which folks are unlikely to do if the Gate passes).  

To address this issue, I am proposing we switch to using a custom Quality Gate with the conditions outlined in the docs.  The main differences between the `Sonar Way` and the `CHT Way` are:

- Remove the `Coverage` condition since we currently are not analyzing code coverage with Sonar.
- Replace the `Maintainability Rating` condition with a simple `Issues` condition. 

Originally, I thought that having an `A` "Maintainability Rating" would mean that your code had no identified issues.  Instead, it is actually [a more complex algorithm](https://docs.sonarsource.com/sonarqube/latest/user-guide/metric-definitions/#maintainability) that is somehow related to the size/age/complexity of the code-base.  Unfortunately, this algorithm does not seem to be particularly useful for our code base.  I found [this PR](https://sonarcloud.io/summary/new_code?id=medic_cht-core&pullRequest=8629) that has an `A` Maintainability rating, but has 229 code smell issues (31 of which are High Severity).  For our purposes, I think we expect new code to have _no issues at all_ and so we can just evaluate that value in our Quality Gate and not care about the Maintainability rating.....