### PR TITLE
fix: Remove H1 for test page

### DIFF
--- a/content/en/contribute/code/core/automated-tests.md
+++ b/content/en/contribute/code/core/automated-tests.md
@@ -9,8 +9,6 @@ aliases: >
   /contribute/code/core/fixing-e2e-tests
 ---
 
-# Automated Tests
-
 ## Unit Tests
 
 Each unit test is only intended to validate an isolated piece (unit) of functionality separated from the rest of the system. They can use mocking to replicate the behavior of other parts of the system.


### PR DESCRIPTION
The Hugo template takes this from the markdown metadata and prints that as an H1 already. Having it again on the page resulted in a duplicate H1.
