### PR TITLE
chore(#1233): Document CHT installation in new Mac

### DIFF
--- a/content/en/contribute/code/core/dev-environment.md
+++ b/content/en/contribute/code/core/dev-environment.md
@@ -86,7 +86,7 @@ npm ci --legacy-peer-deps
 
 CouchDB execution differs depending on whether you're running CHT 3.x or 4.x. Follow the instructions in one of the sections below.
 
-If you are using a MacBook with the new Apple silicon chips (M1, M2 etc, with the ARM architecture) skip to the [CouchDB Setup in 4.x for Apple Silicon](#couchdb-setup-in-4x-for-apple-silicon) section in CouchDB Setup in CHT 4.x.
+If you are using a MacBook with the new Apple silicon chips (M1, M2 etc, with the ARM architecture) skip to the [CouchDB Setup in 4.x for Apple Silicon Chip](#couchdb-setup-in-4x-for-apple-silicon-chip) section in CouchDB Setup in CHT 4.x.
 
 #### CouchDB Setup in CHT 3.x
 
@@ -139,7 +139,7 @@ Now you can start CouchDB. The login for your CHT instance will be `medic` and t
 cd ~/cht-docker 
 COUCHDB_USER=medic COUCHDB_PASSWORD=password docker-compose -f docker-compose.yml -f couchdb-override.yml up -d
 ```
-#### CouchDB Setup in 4.x for Apple Silicon chip
+#### CouchDB Setup in 4.x for Apple Silicon Chip
 
 You will need to build the Docker images locally on your machine because the images hosted publicly do not currently support Apple's ARM architecture. While in the root directory of your `cht-core` project:
 

--- a/content/en/contribute/code/core/dev-environment.md
+++ b/content/en/contribute/code/core/dev-environment.md
@@ -139,7 +139,7 @@ Now you can start CouchDB. The login for your CHT instance will be `medic` and t
 cd ~/cht-docker 
 COUCHDB_USER=medic COUCHDB_PASSWORD=password docker-compose -f docker-compose.yml -f couchdb-override.yml up -d
 ```
-#### CouchDB Setup in 4.x for Apple Silicon
+#### CouchDB Setup in 4.x for Apple Silicon chip
 
 You will need to build the Docker images locally on your machine because the images hosted publicly do not currently support Apple's ARM architecture. While in the root directory of your `cht-core` project:
 

--- a/content/en/contribute/code/core/dev-environment.md
+++ b/content/en/contribute/code/core/dev-environment.md
@@ -86,7 +86,7 @@ npm ci --legacy-peer-deps
 
 CouchDB execution differs depending on whether you're running CHT 3.x or 4.x. Follow the instructions in one of the sections below.
 
-If you are using a MacBook with the new Apple silicon chips (M1 or M2) skip to the [CouchDB Setup in 4.x for Apple Silicon](#couchdb-setup-in-4x-for-apple-silicon) section for CouchDB Setup in CHT 4.x.
+If you are using a MacBook with the new Apple silicon chips (M1, M2 etc, with the ARM architecture) skip to the [CouchDB Setup in 4.x for Apple Silicon](#couchdb-setup-in-4x-for-apple-silicon) section in CouchDB Setup in CHT 4.x.
 
 #### CouchDB Setup in CHT 3.x
 

--- a/content/en/contribute/code/core/dev-environment.md
+++ b/content/en/contribute/code/core/dev-environment.md
@@ -147,7 +147,7 @@ You will need to build the Docker images locally on your machine because the ima
 npm run local-images
 ```
 
-After the `npm` command completes successfully, a `local-build` folder will be created in the root directory of your `cht` project.
+After the `npm` command completes successfully, a `local-build` folder will be created in the root directory of your `cht-core` project.
 
 Confirm you have these four files in the `local-build` folder: `docker-compose.yml`, `cht-core.yml`, `cht-couchdb.yml` and `cht-couchdb-clustered.yml`
 

--- a/content/en/contribute/code/core/dev-environment.md
+++ b/content/en/contribute/code/core/dev-environment.md
@@ -149,6 +149,8 @@ npm run local-images
 
 After the `npm` command completes successfully, a `local-build` folder will be created in the root directory of your `cht` project.
 
+Confirm you have these four files in the `local-build` folder: `docker-compose.yml`, `cht-core.yml`, `cht-couchdb.yml` and `cht-couchdb-clustered.yml`
+
 Open the project with your favorite text editor, navigate inside the `local-build` folder and update the `cht-couchdb.yml` file with the necessary ports. 
 
 In the `couchdb` configuration inside the `cht-couchdb.yml` file, right after the `volumes` property, add the following properties and save the changes: 
@@ -172,10 +174,11 @@ echo "export COUCH_DB_USER=medic">> ~/.$(basename $SHELL)rc
 echo "export COUCH_DB_PASSWORD=password">> ~/.$(basename $SHELL)rc
 ```
 
-In your terminal, navigate inside the `local-build` folder and start the Docker containers:
+In your terminal, navigate inside the `local-build` folder, stop any running Docker containers and start the CHT Docker containers:
 
 ```shell
 cd ~/cht-core/local-build
+docker kill $(docker ps -q)
 docker-compose -f cht-couchdb.yml up -d
 ``` 
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Update [CHT Core dev environment setup](https://docs.communityhealthtoolkit.org/contribute/code/core/dev-environment/#couchdb-setup-in-cht-4x) to include setup instructions for people using Apple Silicon Macbooks.

In the current Docs, the section [CouchDB Setup in CHT 4.x](https://docs.communityhealthtoolkit.org/contribute/code/core/dev-environment/#couchdb-setup-in-cht-4x:~:text=echo%20%24COUCH_URL-,CouchDB%20Setup%20in%20CHT%204.x,-Create%20a%20docker) includes a command that creates a `docker-compose.yml` file that points to the publicly available images at `public.ecr.aws/medic/cht-couchdb:4.4.0-alpha`

Unfortunately, the images available on there are built for `AMD ` architecture

So when you run the command `COUCHDB_USER=medic COUCHDB_PASSWORD=password docker-compose -f docker-compose.yml -f couchdb-override.yml up -d`

You get this error 
`couchdb The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested`

Because of the lack of `ARM` images, the current workaround is to build the correct images locally.

#1233 

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

