### PR TITLE
fix(#1240): Fix a typo

### DIFF
--- a/content/en/apps/reference/contact-page.md
+++ b/content/en/apps/reference/contact-page.md
@@ -86,7 +86,7 @@ Each condition card is defined as a card object in the `cards` array of `contact
 
 Each care guide accessible from a contact profile is defined as an [App Form]({{< ref "apps/reference/forms/app" >}}). Context information can be provided to forms via the `context` object of `contact-summary.templated.js`.
 
-To show an App Form on a contact's profile, the form's `expression` field in its properties file must evaluate to true for that contact. The context infomation from the profile is accessible as the variable `summary`.
+To show an App Form on a contact's profile, the form's `expression` field in its properties file must evaluate to true for that contact. The context information from the profile is accessible as the variable `summary`.
 
 The context data is also available directly within the app forms' XForm calculations, as `instance('contact-summary')/context/${variable}`. For instance if `context.is_pregnant` is used in the contact summary, it can be accessed in an XForm field's calculation as `instance('contact-summary')/context/is_pregnant`. Note that these fields are not available when editing a previously completed form, or when accessing the form from outside of the profile page.
 


### PR DESCRIPTION
Fixed a typo #1240

# Description
There was a typo in the Care Guides section:

> The context **_infomation_** from the profile is accessible as the variable summary.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

