### PR TITLE
feat(#6612): add note for contact form expression data access

### DIFF
--- a/content/en/apps/reference/forms/contact.md
+++ b/content/en/apps/reference/forms/contact.md
@@ -52,6 +52,10 @@ The `form_id` should follow the pattern `contact:CONTACT_TYPE_ID:ACTION` where C
 
 Starting in cht-core release 3.10, we can now configure property files in contact create forms to show or hide them based on an expression or permission as specified in the [app form schema]({{< ref "apps/reference/forms/app#formsappform_namepropertiesjson" >}}). Note: this applies only to the create form, not the contacts themselves.
 
+{{% alert title="Note" %}}
+The form expression for contact forms will only have access to `user` data. The `contact` and `summary` data are [not currently available](https://github.com/medic/cht-core/issues/6612). 
+{{% /alert %}}
+
 ## Generic contact forms
 
 If your place contact forms are similar across all levels of your specified project hierarchy, you can templatise the form creation process. You will need to create the following files in `forms/contact`: `place-types.json`, `PLACE_TYPE-create.xlsx` and `PLACE_TYPE-edit.xlsx`.


### PR DESCRIPTION
# Description

https://github.com/medic/cht-core/issues/6612

Clarifies that `contact` and `summary` data are not available in contact form expressions.

[Related forum thread](https://forum.communityhealthtoolkit.org/t/disable-members-addition-for-muted-households/3195)

For the record, I believe it is this line that is not passing any value for `user` or `contactSummary`:
https://github.com/medic/cht-core/blob/b7b2629bfe92329f9974e94adc6786bc687f3202/webapp/src/ts/modules/contacts/contacts-content.component.ts#L330

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

