### PR TITLE
fix(#): consistent naming for public key file

### DIFF
--- a/content/en/apps/guides/hosting/4.x/adding-tls-certificates.md
+++ b/content/en/apps/guides/hosting/4.x/adding-tls-certificates.md
@@ -19,7 +19,7 @@ To load your certificates into your CHT instance, we'll be creating an interstit
 You have two files locally on your workstation in the directory you're currently in:
 
    * `key.pem` - the private key for your TLS certificate
-   * `chain.pem` - both the public and any interstitial keys concatenated into one file
+   * `cert.pem` - both the public and any interstitial keys concatenated into one file
 
 Also, be sure you have started your CHT instance once and all your volumes are created.  
 


### PR DESCRIPTION
# Description

Appears this should be cert.pem.  [This line](https://github.com/medic/cht-docs/blob/main/content/en/apps/guides/hosting/4.x/adding-tls-certificates.md?plain=1#L46) uses cert.pem and it is the default [here](https://github.com/medic/cht-core/blob/34edb11f7f5b9a2f945945387e70a762098c8148/nginx/ssl-install.sh#L5). Docker helper maybe uses chain.pem but I don't think this is the default for cht-core self-host. 

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

