### PR TITLE
feat(contact-summary): child reports are only from persons

### DIFF
--- a/content/en/apps/reference/contact-page.md
+++ b/content/en/apps/reference/contact-page.md
@@ -20,7 +20,7 @@ Helper variables and functions for the contact summary can be defined in `contac
 | Variable | Description |
 |---|---|
 | `contact` | The currently selected contact. This has minimal stubs for the `contact.parent`, so if you want to refer to a property on the parent use `lineage` below.| 
-| `reports` | An array of reports for the contact or for any of the contact's children. Note that if the contact has more than 50 reports, only the 50 with the latest `reported_date` values will be provided. | 
+| `reports` | An array of reports for the contact or for any of the contact's `person` children. Note that if the contact has more than 50 reports, only the 50 with the latest `reported_date` values will be provided. | 
 | `lineage` | An array of the contact's parents (2.13+), eg `lineage[0]` is the parent, `lineage[1]` is the grandparent, etc. Each lineage entry has full information for the contact, so you can use `lineage[1].contact.phone`. `lineage` will include only those contacts which are visible to the logged in profile | 
 | `targetDoc` | Doc with [`target`]({{< ref "core/overview/db-schema#targets" >}} ) document of the contact, hydrated with the config information of every target it contains a value for. If there is no target document available (for example when viewing a contact that does not upload targets), this value will be `undefined`. This value might also be `undefined` if the contact has not yet synced the current target document. Added in `3.9.0`. |
 | `uhcStats` | Object containing UHC stats information. Added in `v3.12.0` |


### PR DESCRIPTION
# Description

This adds a further clarification on top of https://github.com/medic/cht-docs/pull/1257 to note that only reports from `person` children are actually passed to the contact-summary.  So, if you have a CHW Area that has some direct `person` children as well as some Households that are also direct children of the CHW Area, the contact-summary for the CHW Area will have access to the reports for the `person` children, but not to reports associated with the Household contacts.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

