### PR TITLE
feat(static-analysis): add doc for ignoring code blocks in Sonar

### DIFF
--- a/content/en/contribute/code/static-analysis.md
+++ b/content/en/contribute/code/static-analysis.md
@@ -37,6 +37,7 @@ When Sonar flags an issue with the code in your pull request, use this decision 
       1. [Remove the rule]({{< ref "#removing-a-rule" >}}) from the default Quality Profile.
    1. If it does not make sense to apply the rule to this particular code, you can do one of the following:
       1. Completely ignore Sonar issues [on that line of code](https://docs.sonarsource.com/sonarqube/latest/user-guide/issues/#technical-review) by adding the `// NOSONAR` comment to the end of the line.
+      1. Completely ignore Sonar issues for [that block of code]({{< ref "#ignoring-all-rules-for-a-block-of-code" >}}).
       1. Update the `.sonarcloud.properties` to [ignore _that rule_ for that particular file]({{< ref "#ignoring-a-specific-rule-for-a-file" >}}).
       1. Update the `.sonarcloud.properties` to [ignore _all rules_ for that particular file]({{< ref "#ignoring-all-rules-for-a-file" >}}) (useful if the file has been copied from an external dependency).
 
@@ -79,6 +80,20 @@ sonar.test.inclusions=**/test*/**/*
 ```
 
 Additionally, the `.sonarcloud.properties` file can contain configuration regarding ignoring certain rules.
+
+##### Ignoring all rules for a block of code
+
+You can ignore all the rules for a block of code by telling Sonar to [ignore the block](https://docs.sonarsource.com/sonarqube/latest/project-administration/analysis-scope/#ignoring-blocks-within-files). First, make sure your `.sonarcloud.properties` file has the following configuration:
+
+```properties
+
+```properties
+sonar.issue.ignore.block=e1
+sonar.issue.ignore.block.e1.beginBlockRegexp=NOSONAR_BEGIN
+sonar.issue.ignore.block.e1.endBlockRegexp=NOSONAR_END
+```
+
+Then simply put `//NOSONAR_BEGIN` before the block to ignore and `//NOSONAR_END` after the block.
 
 ##### Ignoring all rules for a file
 


### PR DESCRIPTION
# Description

Documents the method used in https://github.com/medic/cht-core/pull/8800 to ignore whole code blocks in Sonar.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

