### PR TITLE
feat(sonar): recommend setting NCD to 1 day

### DIFF
--- a/content/en/contribute/code/static-analysis.md
+++ b/content/en/contribute/code/static-analysis.md
@@ -52,9 +52,11 @@ When Sonar flags an issue with the code in your pull request, use this decision 
 
 #### New Code Definition
 
-When setting up a new repository in SonarCloud, you will be asked to define what is considered to be "new code". This is used to determine which code in the default branch is considered "new" (affects reporting of issues, etc).
+When setting up a new repository in SonarCloud, you will be asked to define what is considered to be "new code". This is used to determine which code in the default branch is considered "new" (affects reporting of issues, etc). The new code definition is not applied to Sonar analysis of a PR. In that case, only the changes in the PR are considered "new".
 
 Consult [the documentation](https://docs.sonarcloud.io/improving/new-code-definition/) for more details on the options available. For projects that do not use Gradle or Maven for version management, the `Number of days` option is recommended (since `Previous version` would require maintaining a version number in the `.sonarcloud.properties` file).
+
+If you are using the `CHT Way` quality gate (or a similar zero-tolerance quality gate) it is recommended to set `Number of days = 1`. With a zero-tolerance quality gate, only issue-free code can be merged to the default branch. So, there is no need to check for issues accumulated over time. Also, having a higher `Number of days` opens up a greater opportunity for Sonar to introduce a _new rule_ that will fail some code previously added to the default branch (code that is only included in the latest analysis because of the configured `Number of days`).
 
 ### Sonar Configuration
 


### PR DESCRIPTION
# Description

Sonar analysis [failed](https://sonarcloud.io/summary/new_code?id=medic_cht-core&branch=master) on the latest commit to cht-core `master`.  The [PR](https://github.com/medic/cht-core/pull/8744) that actually added the code causing the issue was merged 9 days ago.  However, at the time the PR was merged, it passed the Sonar check!  It turns out, Sonar added [a new rule](https://sonarcloud.io/organizations/medic/rules?open=typescript%3AS1444&rule_key=typescript%3AS1444) today and failed that code [ex post facto](https://en.wikipedia.org/wiki/Ex_post_facto_law) because it was considered to be "new" by our Sonar New Code Definition for cht-core (which is currently set to consider all changes from the last `30 days` as "new").

My proposal is to lower our NCD value to just `1 day` to avoid these issues in the future.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

