### PR TITLE
fix(na) move exports into general CHT setup, out of CHT 3.x setup

### DIFF
--- a/content/en/contribute/code/core/dev-environment.md
+++ b/content/en/contribute/code/core/dev-environment.md
@@ -87,6 +87,20 @@ To finalise setting up any remaining dependencies build the project by running:
 npm run build-dev
 ```
 
+Every time you run any `npm` or `node` commands, it will expect `COUCH_NODE_NAME` and `COUCH_URL` environment variables to be set:
+
+```shell
+echo "export COUCH_NODE_NAME=nonode@nohost">> ~/.$(basename $SHELL)rc
+echo "export COUCH_URL=http://medic:password@localhost:5984/medic">> ~/.$(basename $SHELL)rc
+. ~/.$(basename $SHELL)rc
+```
+
+To ensure these to exports and sourcing your rc file worked, echo the values back out. You should see `nonode@nohost` and `http://medic:password@localhost:5984/medic`:
+
+```shell
+echo $COUCH_NODE_NAME && echo $COUCH_URL
+```
+
 ### CouchDB
 
 CouchDB execution differs depending on whether you're running CHT 3.x or 4.x. Follow the instructions in one of the sections below.
@@ -103,20 +117,6 @@ Let's ensure CouchDB is set up with a test `curl` call. This should show "nonode
 
 ```shell
 curl -X GET "http://medic:password@localhost:5984/_membership" | jq
-```
-
-Every time you run any `npm` or `node` commands, it will expect `COUCH_NODE_NAME` and `COUCH_URL` environment variables to be set:
-
-```shell
-echo "export COUCH_NODE_NAME=nonode@nohost">> ~/.$(basename $SHELL)rc
-echo "export COUCH_URL=http://medic:password@localhost:5984/medic">> ~/.$(basename $SHELL)rc
-. ~/.$(basename $SHELL)rc
-```
-
-To ensure these to exports and sourcing your rc file worked, echo the values back out. You should see `nonode@nohost` and `http://medic:password@localhost:5984/medic`:
-
-```shell
-echo $COUCH_NODE_NAME && echo $COUCH_URL
 ```
 
 #### CouchDB Setup in CHT 4.x


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

This PR moves the `COUCH_NODE_NAME` and `COUCH_URL` exports into general CHT setup, out of CHT 3.x setup section in CHT Core  developer setup docs

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

