### PR TITLE
fix(na): Remove macOS specific `buildx` instructios for Core Dev Environment

### DIFF
--- a/content/en/contribute/code/core/dev-environment.md
+++ b/content/en/contribute/code/core/dev-environment.md
@@ -123,8 +123,7 @@ curl -X GET "http://medic:password@localhost:5984/_membership" | jq
 
 Create a `docker-compose.yml` and `couchdb-override.yml` files under the `~/cht-docker` folder with this code:
 
-{{< tabpane persistLang=false lang=shell >}}
-{{< tab header="Linux (Ubuntu) & Windows (WSL2)" >}}
+```
 mkdir -p ~/cht-docker
 curl -s -o ~/cht-docker/docker-compose.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:master/docker-compose/cht-couchdb.yml
 cat > ~/cht-docker/couchdb-override.yml << EOF
@@ -135,22 +134,7 @@ services:
           - "5984:5984"
           - "5986:5986"
 EOF
-{{< /tab >}}
-{{< tab header="macOS" >}}
-docker build -t couchdb-apple-silicon ~/cht-core/couchdb/.
-mkdir -p ~/cht-docker
-curl -s -o ~/cht-docker/docker-compose.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:master/docker-compose/cht-couchdb.yml
-cat > ~/cht-docker/couchdb-override.yml << EOF
-version: '3.9'
-services:
-    couchdb:
-        image: couchdb-apple-silicon
-        ports:
-            - "5984:5984"
-            - "5986:5986"
-EOF
-{{< /tab >}}
-{{< /tabpane >}}
+```
 
 Now you can start CouchDB. The login for your CHT instance will be `medic` and the `password` will be password:
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Remove macOS specific `buildx` instructios for Core Dev Environment

Once we [release](https://github.com/medic/cht-core/issues/8823) `4.6.0`, we'll be on to `4.7.0` and `master` will pick up the new [multi-platform builds](https://github.com/medic/cht-core/issues/8841).   At that time, we should be able to remove the `buildx` macOS specific section of the CHT Core Dev setup docs.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

