### PR TITLE
Add page on transparency and accountability

### DIFF
--- a/content/en/contribute/medic/product-development-process/transparency-accountability.md
+++ b/content/en/contribute/medic/product-development-process/transparency-accountability.md
@@ -1,0 +1,34 @@
+---
+title: "Transparency & Accountability"
+linkTitle: "Transparency & Accountability"
+weight: 7
+description: >
+  How we make it easy for others to know what's going on and getting done.
+---
+
+It is important that people around Medic, our partners, and community can always see what is being worked on and that commitments are made and kept. There are a few key ways teammates are expected to operate to enable such transparency and accountability.
+
+## GitHub project boards
+Each FWG has a board where tickets are displayed and actively kept up-to-date. These boards are publicly readable and anyone should be able to see the items on the board, what state they are in, and have an expectation of when they will be done.
+
+At the start of the week tickets should be in the "In Progress" state, which means we are committed to getting it done and into the "Done" state by the end of the week.
+
+Boards are:
+- [Allies](https://github.com/orgs/medic/projects/134/views/3)
+- [Care Teams](https://github.com/orgs/medic/projects/259/views/11)
+- [Ecosystem](https://github.com/orgs/medic/projects/134/views/11)
+- [Infrastructure](https://github.com/orgs/medic/projects/134/views/26)
+
+## Ticket updates
+For any ticket in a state of "In Progress", there should be visible progress within 24 hours. Some example scenarios include:
+1. A developer has started writing code. This is most likely case and is as easy as linking (draft PRs work great for this!) the code being written to the ticket so observers can see commits being made on a branch. Nobody want's to hassle you about how it's going. Let others self-serve on that.
+1. Comments and "thinking out loud" on the ticket, especially when no new code is being pushed up. In such a distributed environment, it's hard to tell the difference between nothing happening and someone thinking through tough stuff. Put some of that tough stuff into a comment on the ticket. It lets others know it's tough and also makes it easier for others to help or learn from.
+1. Work needs to happen, but other things came up. Make a quick comment so others know. It may mean that work won't get done this week, and if that's the case, it is probably for good reason. Silence makes it hard for anyone to understand that "probably for good reason" part though. Help others understand the trade-off you had to make.
+1. Something is blocking progress. First, get that into a comment on the ticket, fast; people can help! Then use additional communication channels to get it unblocked even faster.
+
+## Accountability
+People inside and outside the team need to count on things getting done. That means both knowing what the team is doing and seeing that it got done.
+
+In practice, those GitHub project boards have a status representing the commitments for the week. Things that start the week there need to end the week in the "done" column. This is about setting expectations and holding ourselves accountable to them.
+
+There are times when things are more complicated than imagined, work gets blocked, etc. For those cases we may need to change and adjust on the fly. For the majority of the time though, the expectation is week-over-week we are making and meeting our commitments. 

--- a/content/en/contribute/medic/product-development-process/transparency-accountability.md
+++ b/content/en/contribute/medic/product-development-process/transparency-accountability.md
@@ -16,6 +16,7 @@ At the start of the week tickets should be in the "In Progress" state, which mea
 Boards are:
 - [Allies](https://github.com/orgs/medic/projects/134/views/3)
 - [Care Teams](https://github.com/orgs/medic/projects/259/views/11)
+- [Community](https://github.com/orgs/medic/projects/134/views/20)
 - [Ecosystem](https://github.com/orgs/medic/projects/134/views/11)
 - [Infrastructure](https://github.com/orgs/medic/projects/134/views/26)
 


### PR DESCRIPTION
This is primarily for teammates to understand key expectations around our process and why that matters.
