### PR TITLE
Update muffet.sh to ignore private google docs page on 

### DIFF
--- a/.github/scripts/muffet.sh
+++ b/.github/scripts/muffet.sh
@@ -44,4 +44,4 @@ muffet http://localhost:1313 \
   --exclude "https://docs.google.com/spreadsheets/d/12345ABCDEF/.*" \
   --exclude "https://docs.google.com/document/d/14AuJ7SerLuOPESBjQlJqpBtzwSAoVf5ykTT7fjyJBT0/*" \
   --exclude "https://drive.google.com/file/d/1YPXoba9gVmD7SP-X88PpJIsIVGvY86_G.*" \
-  --exclude "https://doi.org/10.1080/02681102.2019.1667289" \
+  --exclude "https://doi.org/10.1080/02681102.2019.1667289" 

--- a/.github/scripts/muffet.sh
+++ b/.github/scripts/muffet.sh
@@ -42,5 +42,6 @@ muffet http://localhost:1313 \
   --exclude "https://tools.google.com.*" \
   --exclude "https://fhir.org/" \
   --exclude "https://docs.google.com/spreadsheets/d/12345ABCDEF/.*" \
+  --exclude "https://docs.google.com/document/d/14AuJ7SerLuOPESBjQlJqpBtzwSAoVf5ykTT7fjyJBT0/*" \
   --exclude "https://drive.google.com/file/d/1YPXoba9gVmD7SP-X88PpJIsIVGvY86_G.*" \
-  --exclude "https://doi.org/10.1080/02681102.2019.1667289"
+  --exclude "https://doi.org/10.1080/02681102.2019.1667289" \


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

ignore good doc muffet check on [team meeting page](https://docs.communityhealthtoolkit.org/contribute/medic/onboarding/team-meetings/)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

