### PR TITLE
feat(na): Bump hugo to 0.122 & add Docker Compose file, update readme

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-hugo extended_0.101.0
+hugo extended_0.122.0
 golang 1.21.0
 nodejs 16.20.2

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The documentation is built using Markdown pages, which can be converted into a n
 
 ## Build dependencies
 
-The documentation site uses [Hugo](https://gohugo.io/) including the extended version of Hugo. Version v0.122 is used per (see #https://github.com/medic/cht-docs/issues/1302) as denoted in `.tool-versions` [file](https://github.com/medic/cht-docs/blob/main/.tool-versions).
+The documentation site uses [Hugo](https://gohugo.io/) including the extended version of Hugo (see `.tool-versions` [file](https://github.com/medic/cht-docs/blob/main/.tool-versions) for specific version).
 
 To proceed, please choose one of the three options below of Docker, native packages or using `asdf` then proceed to ["Run Hugo" below](#run-hugo) to start your local instance.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The documentation site uses [Hugo](https://gohugo.io/) including the extended ve
 
 To proceed, please choose one of the three options below of Docker, native packages or using `asdf` then proceed to ["Run Hugo" below](#run-hugo) to start your local instance.
 
+For folks using `asdf` and native packages, be sure the correct `hugo` version is installed per `.tool-versions` [file](https://github.com/medic/cht-docs/blob/main/.tool-versions).
+
 ### Docker
 
 Running `hugo` locally using Docker is likely the easiest way to update the docs.  You only need to ensure you have [Docker and Docker compose installed](https://docs.docker.com/compose/install/).

--- a/README.md
+++ b/README.md
@@ -10,20 +10,38 @@ The documentation is built using Markdown pages, which can be converted into a n
 
 ## Build dependencies
 
-The documentation site uses [Hugo](https://gohugo.io/), and specifically uses features found in the extended version of Hugo, v0.76.0 and later. See `.tool-versions` for the currently used version
+The documentation site uses [Hugo](https://gohugo.io/), and specifically uses features found in the extended version of Hugo, v0.76.0 and later. See `.tool-versions` for the currently used version.
 
-[asdf](https://asdf-vm.com/guide/getting-started.html) is the recommended way to manage `hugo` and `golang` versions for local development.
+### Docker
 
-After installing it run:
+Running `hugo` locally using Docker is likely the easiest way to update the docs.  Ensure you have Docker and Docker compose installed, then:
+
+1. Clone the `cht-docs` repo
+1. From the command line, navigate to the local directory where you cloned the repo
+1. Type `docker compose up`
+1. Preview your site in your browser at: http://localhost:1313/
+1. As you make changes to the site, your browser will automatically reload your local dev site so you can easily and quickly see your changes.
+
+
+### Bare-Metal
+
+#### Native packages
+
+If you'd like to install packages directly on your workstation, follow the [installation instructions for your Operating System](https://gohugo.io/getting-started/installing/), and be sure to get the extended version. Most users will be able to simply install using their native package manager like `brew`, `apt` or `snap`. 
+
+#### `asdf` version manager
+
+[asdf](https://asdf-vm.com/guide/getting-started.html) is another way to manage `hugo` and `golang` versions for local development.
+
+After installing `asdf`, run:
 ```shell
 asdf plugin add golang
 asdf plugin add hugo
 ```
-### Installing Hugo Manually
 
-If using `asdf` fails you can try installing Hugo manually. To install, follow the [installation instructions for your Operating System](https://gohugo.io/getting-started/installing/), and be sure to get the extended version. Most users will be able to simply install using their native package manager like `brew`, `apt` or `snap`.
+#### Run Hugo
 
-## Building the Documentation
+For both native packages or `asdf`, you can start your local CHT Docs instance by:
 
 1. Clone the `cht-docs` repo
 1. From the command line, navigate to the local directory where you cloned the repo

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ To proceed, please choose one of the three options below of Docker, native packa
 
 Running `hugo` locally using Docker is likely the easiest way to update the docs.  You only need to ensure you have [Docker and Docker compose installed](https://docs.docker.com/compose/install/).
 
+The steps below will leave a hugo container on your system.  If you're not going to edit docs for the foreseeable future, you can delete it with `docker rm cht-hugo `.
+
 ### Native packages
 
 If you'd like to install packages directly on your workstation, follow the [installation instructions for your Operating System](https://gohugo.io/getting-started/installing/), and be sure to get the extended version. Most users will be able to simply install using their native package manager like `brew`, `apt` or `snap`.

--- a/README.md
+++ b/README.md
@@ -10,26 +10,19 @@ The documentation is built using Markdown pages, which can be converted into a n
 
 ## Build dependencies
 
-The documentation site uses [Hugo](https://gohugo.io/), and specifically uses features found in the extended version of Hugo, v0.76.0 and later. See `.tool-versions` for the currently used version.
+The documentation site uses [Hugo](https://gohugo.io/) including the extended version of Hugo. Version v0.122 is used per (see #https://github.com/medic/cht-docs/issues/1302) as denoted in `.tool-versions` [file](https://github.com/medic/cht-docs/blob/main/.tool-versions).
+
+To proceed, please choose one of the three options below of Docker, native packages or using `asdf` then proceed to ["Run Hugo" below](#run-hugo) to start your local instance.
 
 ### Docker
 
-Running `hugo` locally using Docker is likely the easiest way to update the docs.  Ensure you have Docker and Docker compose installed, then:
+Running `hugo` locally using Docker is likely the easiest way to update the docs.  You only need to ensure you have [Docker and Docker compose installed](https://docs.docker.com/compose/install/).
 
-1. Clone the `cht-docs` repo
-1. From the command line, navigate to the local directory where you cloned the repo
-1. Type `docker compose up`
-1. Preview your site in your browser at: http://localhost:1313/
-1. As you make changes to the site, your browser will automatically reload your local dev site so you can easily and quickly see your changes.
+### Native packages
 
+If you'd like to install packages directly on your workstation, follow the [installation instructions for your Operating System](https://gohugo.io/getting-started/installing/), and be sure to get the extended version. Most users will be able to simply install using their native package manager like `brew`, `apt` or `snap`.
 
-### Bare-Metal
-
-#### Native packages
-
-If you'd like to install packages directly on your workstation, follow the [installation instructions for your Operating System](https://gohugo.io/getting-started/installing/), and be sure to get the extended version. Most users will be able to simply install using their native package manager like `brew`, `apt` or `snap`. 
-
-#### `asdf` version manager
+### `asdf` version manager
 
 [asdf](https://asdf-vm.com/guide/getting-started.html) is another way to manage `hugo` and `golang` versions for local development.
 
@@ -39,15 +32,17 @@ asdf plugin add golang
 asdf plugin add hugo
 ```
 
-#### Run Hugo
+### Run Hugo
 
 For both native packages or `asdf`, you can start your local CHT Docs instance by:
 
 1. Clone the `cht-docs` repo
-1. From the command line, navigate to the local directory where you cloned the repo
-1. Type `hugo server`
-1. Preview your site in your browser at: http://localhost:1313/
-1. As you make changes to the site, your browser will automatically reload your local dev site so you can easily and quickly see your changes.
+2. From the command line, navigate to the local directory where you cloned the repo
+3. To start `hugo` run:
+   * `hugo server` for `asdf` and native packages **OR**
+   * `docker compose up` for Docker compose
+4. Preview your site in your browser at: http://localhost:1313/
+5. As you make changes to the site, your browser will automatically reload your changes.
 
 Any users who experience errors running `hugo server`, please see our [Troubleshooting guide](./troubleshooting.md).
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ asdf plugin add hugo
 
 ### Run Hugo
 
-For both native packages or `asdf`, you can start your local CHT Docs instance by:
+You can start your local CHT Docs instance by:
 
 1. Clone the `cht-docs` repo
 2. From the command line, navigate to the local directory where you cloned the repo

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  hugo:
+    image: jakejarvis/hugo-extended:0.113.0 # note that 0.122 isn't avail, but 0.113 has everything we need for now
+    ports:
+      - 1313:1313
+    volumes:
+      - ./:/src
+    command: server --buildDrafts --buildFuture --bind 0.0.0.0

--- a/compose.yml
+++ b/compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   hugo:
+    container_name: cht-hugo
     image: jakejarvis/hugo-extended:0.113.0 # note that 0.122 isn't avail, but 0.113 has everything we need for now
     ports:
       - 1313:1313

--- a/config.toml
+++ b/config.toml
@@ -71,7 +71,6 @@ time_format_blog = "02.01.2006"
   # replacements = "github.com/google/docsy -> ../../docsy"
   [module.hugoVersion]
     extended = true
-    min = "0.93.0"
   [[module.imports]]
     path = "github.com/google/docsy"
     disable = false


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

This PR: 
* Adds ability to run `hugo server` with Docker compose in addition to native packages via a newly add `compose.yml` file
* updates readme with steps to use newly added compose file
* bumps `hugo` in `.tool-version`  to `0.122`

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

