### PR TITLE
fix: clarify user data in form is from user-settings

### DIFF
--- a/content/en/apps/guides/forms/form-inputs.md
+++ b/content/en/apps/guides/forms/form-inputs.md
@@ -99,10 +99,10 @@ Contact summary data is not available in `contact` forms or in forms created fro
 
 ## `user` data
 
-Both `app` and `contact` forms can access the current user's data at `inputs/user`.  The data provided is simply the [CouchDB doc for the user](https://docs.couchdb.org/en/stable/intro/security.html?highlight=org.couchdb.user#users-documents) (e.g. `org.couchdb.user:username`) plus an additional `language` field that contains the user's currently selected language code.
+Both `app` and `contact` forms can access the current user's data at `inputs/user`.  The data provided is simply the [`user-settings` doc for the user]({{< ref "core/overview/db-schema#users" >}}) (e.g. `org.couchdb.user:username`) plus an additional `language` field that contains the user's currently selected language code.
 
 {{% alert title="Note" %}}
-The CouchDB doc for the user is _NOT_ the same as the CHT _contact_ doc for the user.
+The `user-settings` doc for the user is _NOT_ the same as the CHT _contact_ doc for the user.
 {{% /alert %}}
 
 ### Example of saving `user` data as metadata on a report


### PR DESCRIPTION
This is just a random doc fix for something I noticed was not accurate (even though I was the one who wrote this in the first place...).  

Basically, a users data is stored in [several places](https://docs.communityhealthtoolkit.org/core/overview/db-schema/#users). The current docs make it sound like the data from the `_users` db is loaded into the form.  This is actually not the case. Instead, the users data [loaded into the form](https://github.com/medic/cht-core/blob/15bd199eff7468b23acae5e39b2245ce4b4a5220/webapp/src/ts/services/form.service.ts#L166) is from the `user-settings` doc in the `medic` database.  