### PR TITLE
Update branding.md

### DIFF
--- a/content/en/apps/guides/android/branding.md
+++ b/content/en/apps/guides/android/branding.md
@@ -180,8 +180,6 @@ export ANDROID_KEYSTORE_PASSWORD_NEW_BRAND=dd8668...
 export ANDROID_KEY_PASSWORD_NEW_BRAND=dd8668...
 export ANDROID_SECRETS_IV_NEW_BRAND=88d9c2dea7a9...
 export ANDROID_SECRETS_KEY_NEW_BRAND=2824d02d2bc221f5844b8fe1d928211dcbbc...
-export ANDROID_KEYSTORE_PATH_NEW_BRAND=new_brand.keystore
-export ANDROID_KEY_ALIAS_NEW_BRAND=medicmobile
 
 #
 # The file secrets/secrets-new_brand.tar.gz.enc was created and has to be added to the git
@@ -200,7 +198,7 @@ About the file `secrets/secrets-new_brand.tar.gz.enc`, as the last paragraph in 
 If you want to start over because some of the parameters were wrong, just execute `make org=new_brand keyrm-all` to clean all the files generated. Once committed the `.enc` file, you can delete the uncompressed and unencrypted version with `make org=new_brand keyrm`, it will delete the `new_brand.keystore`, `new_brand_private_key.pepk`, and the unencrypted `.tar.gz` files, that are safer kept in the `.tar.gz.enc` file.
 
 
-### 4. Test locally the keystore
+### 4. Test the keystore locally
 
 **Want to check the keystore?** here are a few things you must test before upload to the repository:
 
@@ -208,7 +206,7 @@ If you want to start over because some of the parameters were wrong, just execut
 
 2. Execute `make org=new_brand keyprint` to see the certificate content, like the org name, the certificate fingerprints, etc.
 
-3. Sign your app! try locally to build the app with the certificate. To create the .apk files run: `make org=new_brand flavor=New_brand assemble`. The "release" files signed should be placed in `build/outputs/apk/new_brand/release/`. To ensure the files were signed with the right signature execute `make keyprint-apk`, it will check the certificate of the first apk file under the `build/` folder:
+3. Sign your app! You can try locally to build the app with the certificate. To create the .apk files run: `make org=new_brand flavor=New_brand assemble`. The "release" files signed should be placed in `build/outputs/apk/new_brand/release/`. To ensure the files were signed with the right signature execute `make keyprint-apk`, it will check the certificate of the first apk file under the `build/` folder:
 
    ```
    make keyprint-apk 
@@ -220,7 +218,7 @@ If you want to start over because some of the parameters were wrong, just execut
    Signer #1 certificate SHA-256 digest: 7f072b...
    ```
 
-Also do the same for the bundle format: build and verify, despite the AAB are not useful for local development. In our example, execute first `make org=new_brand flavor=New_brand bundle`, and then `make keyprint-bundle` to see the signature of one of the `.aab` files generated.
+Also, do the same for the bundle format: build and verify, despite the AAB are not useful for local development. In our example, execute first `make org=new_brand flavor=New_brand bundle`, and then `make keyprint-bundle` to see the signature of one of the `.aab` files generated.
 
 Because the files generated here are signed with the same key that you are going to use in CI, and the files produced in CI will be uploaded to the Play Store later, any file generated locally following the steps above will be compatible with any installation made from the Play Store, means that if a user install the app from the Play Store, and then we want to replace the installation with an alpha version generated in CI or a local version generated in dev environment, it will work without requiring the user to uninstall the app and lost the data.
 


### PR DESCRIPTION
Changes to doc reflecting the changes from https://github.com/medic/cht-android/pull/347.

<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Updating the branding doc. When creating a new flavor now `ANDROID_KEYSTORE_PATH_NEW_BRAND` and `ANDROID_KEY_ALIAS_NEW_BRAND` have been removed from the output in the terminal.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

