### PR TITLE
feat: add docs for upgrading the cht-upgrade-service

### DIFF
--- a/content/en/apps/guides/hosting/4.x/self-hosting/_partial_upgrade_service.md
+++ b/content/en/apps/guides/hosting/4.x/self-hosting/_partial_upgrade_service.md
@@ -1,0 +1,22 @@
+---
+title: "Upgrading the cht-upgrade-service"
+toc_hide: true
+hide_summary: true
+---
+### Upgrading the cht-upgrade-service
+
+The [CHT Upgrade Service](https://github.com/medic/cht-upgrade-service) provides an interface between the CHT Core API and Docker to allow easy startup and one-click upgrades from the CHT Admin UI. Occasionally, the CHT Upgrade Service, itself, will need to be upgraded. If an upgrade is available, it is highly recommended that you install the upgrade for the CHT Upgrade Service before performing further upgrades on your CHT instance. This is done via the following steps:
+
+1. Verify that the _version_ of the `cht-upgrade-service` image in your `./upgrade-service/docker-compose.yml` files is set to `latest`.
+1. Pull the latest `cht-upgrade-service` image from Docker Hub and replace the current container by running the following command:
+    ```shell
+    cd /home/ubuntu/cht/upgrade-service
+    docker compose pull
+    docker compose up --detach
+    ``` 
+
+{{% alert title="Note" %}}
+Upgrading the CHT Upgrade Service will not cause a new CHT version to be installed.  The CHT Core and CouchDB contains are not affected.
+{{% /alert %}}
+
+Follow the [Product Releases channel](https://forum.communityhealthtoolkit.org/c/product/releases/26) on the CHT forum to stay informed about new releases and upgrades.

--- a/content/en/apps/guides/hosting/4.x/self-hosting/multiple-nodes.md
+++ b/content/en/apps/guides/hosting/4.x/self-hosting/multiple-nodes.md
@@ -333,3 +333,5 @@ grep COUCHDB_PASSWORD /home/ubuntu/cht/upgrade-service/.env | cut -d'=' -f2
 ## Upgrades
 
 Upgrades are completely manual for the clustered setup right now. You have to go into each of the docker compose files and modify the image tag and take containers down and restart them.
+
+{{< read-content file="_partial_upgrade_service.md" >}}

--- a/content/en/apps/guides/hosting/4.x/self-hosting/single-node.md
+++ b/content/en/apps/guides/hosting/4.x/self-hosting/single-node.md
@@ -111,3 +111,5 @@ See the [TLS Certificates page]({{< relref "apps/guides/hosting/4.x/adding-tls-c
 ## Upgrades
 
 During upgrades, the CHT upgrade service updates the docker-compose files located in `/home/ubuntu/cht/compose/`. This means that any and all changes made to the docker-compose files will be overwritten. If there is ever a need to make any changes to the docker-compose files, be sure to re-do them post upgrades or should consider implementing them outside of those docker-compose files. 
+
+{{< read-content file="_partial_upgrade_service.md" >}}


### PR DESCRIPTION
# Description

Adds instructions for how to upgrade the `cht-upgrade-service`.  Below is a draft of a forum post that we could make instructing people to take the upgrade.  Let me know how it sounds!  Thanks!

https://github.com/medic/cht-upgrade-service/issues/38
https://github.com/medic/cht-upgrade-service/pull/37

---

## Proposed forum post:

### Announcing a new release of the cht-upgrade-service

We are happy to announce a new release of the [cht-upgrade-service](https://github.com/medic/cht-upgrade-service)!

CHT `4.x` deployments should follow these steps to install the new version of the CHT Upgrade Service:
- [Single Node - Docker](https://docs.communityhealthtoolkit.org/apps/guides/hosting/4.x/self-hosting/single-node/#upgrading-the-cht-upgrade-service)
- [Multiple Nodes - Docker](https://docs.communityhealthtoolkit.org/apps/guides/hosting/4.x/self-hosting/multiple-node/#upgrading-the-cht-upgrade-service)

(Deployments hosted via Kubernetes do not include the `cht-upgrade-service` and so no action is required.)

#### Docker 26 Incompatibility

The new release of the `cht-upgrade-service` includes a fix required for the Upgrade Service to be [compatible with Docker 26](https://github.com/medic/cht-upgrade-service/issues/38). You must take this release before performing an upgrade of the CHT on a host running Docker 26. Otherwise, the CHT upgrade will fail to complete.

##### Recovering from a failed CHT upgrade with Docker 26

Thankfully, if you do try to upgrade your CHT instance on a host running Docker 26 without first installing the latest version of the CHT Upgrade Service, the recovery is pretty simple. Run the steps linked above to install the latest version of the CHT Upgrade Service.  Once the new `cht-upgrade-service` container starts it will complete the CHT upgrade.

---

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

