### PR TITLE
Chore: reword to avoid ambiguity

### DIFF
--- a/content/en/contribute/code/core/deploy-on-eks.md
+++ b/content/en/contribute/code/core/deploy-on-eks.md
@@ -88,7 +88,7 @@ After you have created a ticket per "Request permission" above, you should get a
    * Put a UUID in `secret` - the command `uuidgen` is great for this
    * Update `host` to be your `username`.  For example: `mrjones.dev.medicmobile.org`
 4. Use `uuidgen` to fill in the `secret` in `values.yaml`
-5. Use a good passphrase (diceware!) to fill in `password` in `values.yaml`. _Please note that a few special characters are unsupported in this field like `:`, `@`, `"`, `'`, etc. Also, do not use quotes `""` to enclose your password, and do not use spaces in your password. This will not impact the deployment but will not let you log in to the CHT instance._
+5. Use a good passphrase (diceware!) to fill in `password` in `values.yaml`. _Please note that a few special characters are unsupported in this field like `:`, `@`, `"`, `'`, etc. Add your password as a string by enclosing it in quotes `""`, and do not use spaces in your password. This will not impact the deployment but will not let you log in to the CHT instance._
 6. Ensure you have the latest code of `cht-core` [repo](https://github.com/medic/cht-core):
    ```shell
    git checkout master;git pull origin


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

I found this line in the docs abit confusing [Also, do not use quotes "" to enclose your password, and do not use spaces in your password](https://docs.communityhealthtoolkit.org/contribute/code/core/deploy-on-eks/#:~:text=Also%2C%20do%20not%20use%20quotes%20%22%22%20to%20enclose%20your%20password%2C%20and%20do%20not%20use%20spaces%20in%20your%20password). it seems to imply one should not enter the password as a string in the values file.

While you do not explicitly need to wrap `strings` in quotes in `yaml` as explained in [SO post](https://stackoverflow.com/questions/19109912/yaml-do-i-need-quotes-for-strings-in-yaml) and random [blog post](https://brettops.io/blog/yaml-strings/), there are some edge cases. 

Therefore, to avoid any possible issues with setting the bugs lets have the docs mention it's best to use quotes. 

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

