### PR TITLE
fix: correct typo in docs for upgrading the cht-upgrade-service

### DIFF
--- a/content/en/apps/guides/hosting/4.x/self-hosting/_partial_upgrade_service.md
+++ b/content/en/apps/guides/hosting/4.x/self-hosting/_partial_upgrade_service.md
@@ -16,7 +16,7 @@ The [CHT Upgrade Service](https://github.com/medic/cht-upgrade-service) provides
     ``` 
 
 {{% alert title="Note" %}}
-Upgrading the CHT Upgrade Service will not cause a new CHT version to be installed.  The CHT Core and CouchDB contains are not affected.
+Upgrading the CHT Upgrade Service will not cause a new CHT version to be installed.  The CHT Core and CouchDB containers are not affected.
 {{% /alert %}}
 
 Follow the [Product Releases channel](https://forum.communityhealthtoolkit.org/c/product/releases/26) on the CHT forum to stay informed about new releases and upgrades.


### PR DESCRIPTION
# Description
Noticed typo right after publishing these new docs...

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

