### PR TITLE
feat(na): add setup steps for stand along SQL Expoerter on Posgtres server

### DIFF
--- a/content/en/hosting/monitoring/setup.md
+++ b/content/en/hosting/monitoring/setup.md
@@ -148,7 +148,7 @@ Always run this longer version of the `docker compose` command which specifies b
 
 While not the default setup, and not what most deployments need, you may want to set up a way to monitor couch2pg data without sharing any Postgres credentials. Instead of sharing credentials, you expose an HTTP endpoint that requires no login or password.  Of course, similar to  CHT Core's [Monitoring API]({{< relref "apps/reference/api#get-apiv2monitoring" >}}), this endpoint should be configured to not share sensitive information (since it will be publically accessible).
 
-To run a remote instance of only the SQL Exporter without Watchdog on your Postgres server:
+To run a remote instance of only the SQL Exporter on your Postgres server:
 
 1. Clone this repo: `git clone git@github.com:medic/cht-watchdog.git` and `cd` into `cht-watchdog`
 2. Copy `exporters/postgres/sql_servers_example.yml` to `exporters/postgres/sql_servers.yml`

--- a/content/en/hosting/monitoring/setup.md
+++ b/content/en/hosting/monitoring/setup.md
@@ -174,7 +174,7 @@ To run a remote instance of only the SQL Exporter on your Postgres server:
     ```
    
 
-\* _The `stand-alone.yml` and `scrape-only.yml` compose files overrides the some service with an instance of Alpine Linux that does nothing but start and then immediately exit.  This is done so that no manual edits are needed to any compose files._ 
+\* _The `stand-alone.yml` and `scrape-only.yml` compose files override some services.  This is done so that no manual edits are needed to any compose files._ 
 
 #### Prometheus Retention and Storage
 

--- a/content/en/hosting/monitoring/setup.md
+++ b/content/en/hosting/monitoring/setup.md
@@ -157,7 +157,7 @@ To run a remote instance of only the SQL Exporter on your Postgres server:
 5. In the new `.env` file, edit `SQL_EXPORTER_IP` to be public IP of the Posgtres server
 6. Start the service with these two compose files*:
    ```shell
-   docker compose --env-file .env  -f exporters/postgres/compose.yml -f exporters/postgres/stand-alone.yml up -d
+   docker compose --env-file .env  -f exporters/postgres/compose.yml -f exporters/postgres/compose.stand-alone.yml up -d
    ```
 7. Verify that you see the SQL Exporters metrics:  If `SQL_EXPORTER_IP` was set to `10.220.249.15`, then this would be: `http://10.220.249.15:9399/metrics`. The last line starting with `up{job="db_targets"...` should end in a `1` denoting the system is working. If it ends in `0` - check your docker logs for errors.
 8. On your watchdog instance, create a custom scrap definition file: `cp exporters/postgres/scrape.yml ./exporters/postgres/scrape-custom.yml`
@@ -168,13 +168,13 @@ To run a remote instance of only the SQL Exporter on your Postgres server:
         static_configs:
           - targets: ['10.220.249.15:9399']
    ```
-10. Finally, on your watchdog instance, start (or restart) your server including the `scrape-only.yml` compose file:
+10. Finally, on your watchdog instance, start (or restart) your server including the `compose.scrape-only.yml` compose file:
     ```bash
-    docker compose --env-file .env  -f exporters/postgres/compose.yml -f exporters/postgres/scrape-only.yml up -d
+    docker compose --env-file .env  -f exporters/postgres/compose.yml -f exporters/postgres/compose.scrape-only.yml up -d
     ```
    
 
-\* _The `stand-alone.yml` and `scrape-only.yml` compose files override some services.  This is done so that no manual edits are needed to any compose files._ 
+\* _The `compose.stand-alone.yml` and `compose.scrape-only.yml` compose files override some services.  This is done so that no manual edits are needed to any compose files._ 
 
 #### Prometheus Retention and Storage
 

--- a/content/en/hosting/monitoring/setup.md
+++ b/content/en/hosting/monitoring/setup.md
@@ -144,6 +144,25 @@ With the [release of 1.1.0](https://github.com/medic/cht-watchdog/releases/tag/1
 Always run this longer version of the `docker compose` command which specifies both compose files for all future [upgrades](#upgrading).
 {{% /alert %}}
 
+#### couch2pg Data (Remote)
+
+While not the default setup, and not what most deployments need, you may want to set up a way to monitor couch2pg backlog without sharing any Postgres credentials. Instead of sharing credentials, you expose just an HTTP endpoint that requires no login or password.  It shares no sensitive information that isn't already public via your CHT Core's [Monitoring API]({{< relref "apps/reference/api#get-apiv2monitoring" >}}).  
+
+To run a remote instance of only the SQL Exporter without Watchdog on your Postgres server:
+
+1. Clone this repo: `git clone git@github.com:medic/cht-watchdog.git` and `cd` into `cht-watchdog`
+2. Copy `exporters/postgres/sql_servers_example.yml` to `exporters/postgres/sql_servers.yml`
+3. Edit the new `exporters/postgres/sql_servers.yml` file to have the correct credentials for your server. You need to set the URL on the left to be the same as it is in your `cht-instances.yml` on  your Watchdog server.  You need to update the `USERNAME` and `PASSWORD`.   You may need to update the IP address also.
+4. Copy `.env.example` to `.env` 
+5. In the new `.env` file, edit `SQL_EXPORTER_IP` to be public IP of the Posgtres server
+6. Start the service with these two compose files*:
+   ```shell
+   docker compose --env-file .env  -f exporters/postgres/compose.yml -f exporters/postgres/stand-alone.yml up
+   ```
+7. On your watchdog instance TK
+
+\* _The `stand-alone.yml` compose file overrides the `prometheus` service with an instance of Alpine Linux that does nothing but start and then immediately exit.  This is done so that no manual edits are needed to any compose files, just the use of the `stand-alone.yml`_ 
+
 #### Prometheus Retention and Storage
 
 By default, historical monitoring data will be stored in Prometheus (`PROMETHEUS_DATA` directory) for 60 days (configurable by `PROMETHEUS_RETENTION_TIME`). A longer retention time can be configured to allow for longer-term analysis of the data.  However, this will increase the size of the Prometheus data volume.  See the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/storage/) for more information.

--- a/content/en/hosting/monitoring/setup.md
+++ b/content/en/hosting/monitoring/setup.md
@@ -146,7 +146,7 @@ Always run this longer version of the `docker compose` command which specifies b
 
 #### couch2pg Data (Remote)
 
-While not the default setup, and not what most deployments need, you may want to set up a way to monitor couch2pg backlog without sharing any Postgres credentials. Instead of sharing credentials, you expose just an HTTP endpoint that requires no login or password.  It shares no sensitive information that isn't already public via your CHT Core's [Monitoring API]({{< relref "apps/reference/api#get-apiv2monitoring" >}}).  
+While not the default setup, and not what most deployments need, you may want to set up a way to monitor couch2pg data without sharing any Postgres credentials. Instead of sharing credentials, you expose an HTTP endpoint that requires no login or password.  Of course, similar to  CHT Core's [Monitoring API]({{< relref "apps/reference/api#get-apiv2monitoring" >}}), this endpoint should be configured to not share sensitive information (since it will be publically accessible).
 
 To run a remote instance of only the SQL Exporter without Watchdog on your Postgres server:
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Describes how to use YAML files to allow watchdog to monitor a remote postgres instances for couch2pg backlog but not need any postgress credentials or have an SSH tunnel to the server

If following these steps, please be sure to use `stand-alone-couch2pg-backlog-99` branch when testing as the changes are not yet in `main`.  This needs to be done on test Postgres server as well as test Watchdog server.

per https://github.com/medic/cht-watchdog/issues/99

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

