### PR TITLE
feat: add contributor hall of fame

### DIFF
--- a/content/en/contribute/code/_index.md
+++ b/content/en/contribute/code/_index.md
@@ -101,7 +101,7 @@ If you believe you've found a security vulnerability in one of our products or p
 
 - Description of the location and potential impact of the vulnerability;
 - A detailed description of the steps required to reproduce the vulnerability (proof of concept source code, screenshots, and compressed screen captures are all helpful to us); and
-- Your name/handle and a link for recognition in our Hall of Fame.
+- Your name/handle and a link for recognition in our [Hall of Fame]({{% ref "./hall-of-fame" %}}).
 
 ### Code of Conduct
 

--- a/content/en/contribute/code/hall-of-fame.md
+++ b/content/en/contribute/code/hall-of-fame.md
@@ -1,0 +1,27 @@
+---
+title: "Contributor Hall of Fame"
+linkTitle: "Hall of Fame"
+weight: 40
+description: >
+  Tributes to those who have contributed to the codebase
+---
+
+#### Code
+
+Thank you to everyone who has contributed to the CHT codebase over the years! To see the full list, visit each repo on GitHub.
+
+- [CHT Android](https://github.com/medic/cht-android/graphs/contributors)
+- [CHT Conf](https://github.com/medic/cht-conf/graphs/contributors)
+- [CHT Core](https://github.com/medic/cht-core/graphs/contributors)
+- [CHT Docs](https://github.com/medic/cht-docs/graphs/contributors)
+- [CHT Interoperability](https://github.com/medic/cht-interoperability/graphs/contributors)
+- [CHT Pipeline](https://github.com/medic/cht-pipeline/graphs/contributors)
+- [CHT Sync](https://github.com/medic/cht-sync/graphs/contributors)
+- [CHT Watchdog](https://github.com/medic/cht-watchdog/graphs/contributors)
+
+#### Security
+
+Kudos to everyone who has disclosed security vulnerabilities.
+
+1. [Alex Anderson](https://github.com/alxndrsn) with 4 disclosures<br>
+[#9122](https://github.com/medic/cht-core/issues/9122), [#9121](https://github.com/medic/cht-core/issues/9121), [#9120](https://github.com/medic/cht-core/issues/9120), [#9108](https://github.com/medic/cht-core/issues/9108)


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

The security researcher hall of fame is something we've quoted in our docs but never had one because nobody has ever disclosed a vulnerability outside of Medic before. Until now!

This is what it looks like (on my machine).

![image](https://github.com/medic/cht-docs/assets/2064938/bf9872c1-d150-4b32-8a79-b0e74cf38f37)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

