### PR TITLE
fix: Fix link in Create your Android Flavor's Release section

### DIFF
--- a/content/en/apps/guides/android/branding.md
+++ b/content/en/apps/guides/android/branding.md
@@ -233,7 +233,7 @@ Releasing a new flavor requires the following steps:
 1. Make a pull request to the release branch in the CHT Android repository.
 2. Once approved it's recommended to create an alpha version to do final tests.
 3. Merge the pull request.
-4. [Release the flavor]({{< ref "apps/guides/android/publishing" >}}).
+4. [Release the flavor]({{< ref "contribute/code/android/releasing" >}}).
 
 ### 6. Publish the app
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Fix the link in the [Building CHT Android Flavors page](https://docs.communityhealthtoolkit.org/apps/guides/android/branding/#5-release-the-new-flavor) in the [Release section](https://docs.communityhealthtoolkit.org/apps/guides/android/branding/#5-release-the-new-flavor) that was redirecting to the publishing page instead. New link to release page is [this](https://docs.communityhealthtoolkit.org/contribute/code/android/releasing/) instead.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

Fixes: #1399 
