### PR TITLE
fix(#1403): Improve 'Adding Privacy Policies to Apps'

### DIFF
--- a/content/en/apps/guides/privacy/privacy-policy.md
+++ b/content/en/apps/guides/privacy/privacy-policy.md
@@ -14,7 +14,8 @@ Privacy policies are now publicly accessible rather than only being available af
 
 ![Privacy Policy on login page](privacy.policy.login.page.png)
 
-Add these HTML files to the `privacy-policies` folder in your configuration, and associate them to the correct language in the `privacy-policies.json` file, which should reside in the root of the project directory, not inside the privacy_policies folder.
+Add these HTML files to the `privacy-policies` folder in your configuration. The `privacy-policies.json` file, which associates the HTML files with the correct language, should reside in the root of the project directory, not inside the `privacy_policies` folder.
+
 ```json
 {
   "en": "en.attachment.html",
@@ -31,8 +32,6 @@ There are two ways to add or edit a privacy policy:
 ```bash
 cht --local upload-privacy-policies
 ```
-Ensure the privacy-policies.json file is placed in the root of the project directory.
-
 
 2. Update and view privacy policies in the [Admin Console]({{< relref "apps/features/admin" >}}), under `Display` > `Privacy Policies`
 

--- a/content/en/apps/guides/privacy/privacy-policy.md
+++ b/content/en/apps/guides/privacy/privacy-policy.md
@@ -14,7 +14,7 @@ Privacy policies are now publicly accessible rather than only being available af
 
 ![Privacy Policy on login page](privacy.policy.login.page.png)
 
-Add these HTML files to the `privacy-policies` folder in your configuration, and associate them to the correct language in the `privacy-policies.json` file.
+Add these HTML files to the `privacy-policies` folder in your configuration, and associate them to the correct language in the `privacy-policies.json` file, which should reside in the root of the project directory, not inside the privacy_policies folder.
 ```json
 {
   "en": "en.attachment.html",
@@ -31,6 +31,8 @@ There are two ways to add or edit a privacy policy:
 ```bash
 cht --local upload-privacy-policies
 ```
+Ensure the privacy-policies.json file is placed in the root of the project directory.
+
 
 2. Update and view privacy policies in the [Admin Console]({{< relref "apps/features/admin" >}}), under `Display` > `Privacy Policies`
 


### PR DESCRIPTION

<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Clarified location of privacy-policies.json file in the documentation

The guide has been updated to specify that the privacy-policies.json file should reside in the root of the project directory rather than inside the privacy_policies folder. This change ensures users place the file correctly to avoid configuration issues during the upload-privacy-policies action.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

