### PR TITLE
Clarify muting transition configuration options

### DIFF
--- a/content/en/apps/reference/app-settings/transitions.md
+++ b/content/en/apps/reference/app-settings/transitions.md
@@ -434,7 +434,7 @@ Configuration is stored in the `muting` field of `app_settings.json`.
 | `messages` | List of tasks/errors that will be created, determined by `event_type`. Optional. |
 
 {{% alert title="Note" %}}
-Contact forms cannot trigger muting or unmutting, but any `data_record` that has a `form` property can.
+Contact forms cannot trigger muting or unmuting, but any `data_record` that has a `form` property can.
 {{% /alert %}}
 
 

--- a/content/en/apps/reference/app-settings/transitions.md
+++ b/content/en/apps/reference/app-settings/transitions.md
@@ -433,6 +433,11 @@ Configuration is stored in the `muting` field of `app_settings.json`.
 | `validations` | List of form fields validations. All mute & unmute forms will be subjected to these validation rules. Invalid forms will not trigger muting/unmuting actions. Optional. |
 | `messages` | List of tasks/errors that will be created, determined by `event_type`. Optional. |
 
+{{% alert title="Note" %}}
+Contact forms cannot trigger muting or unmutting, but any `data_record` that has a `form` property can.
+{{% /alert %}}
+
+
 Supported `events_types` are:
 
 | Event Type | Trigger |

--- a/content/en/apps/reference/app-settings/transitions.md
+++ b/content/en/apps/reference/app-settings/transitions.md
@@ -434,7 +434,7 @@ Configuration is stored in the `muting` field of `app_settings.json`.
 | `messages` | List of tasks/errors that will be created, determined by `event_type`. Optional. |
 
 {{% alert title="Note" %}}
-Contact forms cannot trigger muting or unmuting, but any `data_record` that has a `form` property can.
+Contact forms cannot trigger muting or unmuting, but any `data_record` that has a `form` property (typically a [Report]({{< ref "core/overview/db-schema#reports" >}})) can.
 {{% /alert %}}
 
 


### PR DESCRIPTION
Just trying to clarify the muting transition docs re: [this forum conversation](https://forum.communityhealthtoolkit.org/t/is-it-possible-for-a-contact-edit-form-to-trigger-the-mute-action/3543/1
)

