### PR TITLE
 chore(na): add prior contributors fof 4.x releases

### DIFF
--- a/content/en/core/releases/4.0.0.md
+++ b/content/en/core/releases/4.0.0.md
@@ -152,3 +152,26 @@ Previously users who tried to log in before server start up had completed would 
 - [#7817](https://github.com/medic/cht-core/issues/7817): Update release build schema to v2
 - [#7826](https://github.com/medic/cht-core/issues/7826): Publish branch and alpha docker images in public ECR
 - [#7864](https://github.com/medic/cht-core/issues/7864): Expose CouchDb port 5986 to the docker network
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Lore](https://github.com/lorerod)
+- [Gareth Bowen](https://github.com/garethbowen)
+- [Ashley](https://github.com/mrjones-plip)
+- [Diana Barsan](https://github.com/dianabarsan)
+- [bedengaruko](https://github.com/bedengaruko)
+- [Mokhtar](https://github.com/m5r)
+- [Jennifer Q](https://github.com/latin-panda)
+- [Tatiana Lépiz](https://github.com/tatilepizs)
+- [elvisdorkenoo](https://github.com/elvisdorkenoo)
+- [Njuguna Ndung'u](https://github.com/njogz)
+- [Joshua Kuestersteffen](https://github.com/jkuester)
+- [Prajwol Shrestha](https://github.com/PrjShrestha)
+- [Jonathan](https://github.com/jonathanbataire)
+- [Marc Abbyad](https://github.com/abbyad)
+- [Henok](https://github.com/henokgetachew)
+- [Hareet](https://github.com/Hareet)
+

--- a/content/en/core/releases/4.0.0.md
+++ b/content/en/core/releases/4.0.0.md
@@ -160,7 +160,7 @@ Thanks to all who committed changes for this release!
 
 - [Lore](https://github.com/lorerod)
 - [Gareth Bowen](https://github.com/garethbowen)
-- [Ashley](https://github.com/mrjones-plip)
+- [mrjones](https://github.com/mrjones-plip)
 - [Diana Barsan](https://github.com/dianabarsan)
 - [bedengaruko](https://github.com/bedengaruko)
 - [Mokhtar](https://github.com/m5r)

--- a/content/en/core/releases/4.0.1.md
+++ b/content/en/core/releases/4.0.1.md
@@ -27,3 +27,12 @@ None.
 - [#7918](https://github.com/medic/cht-core/issues/7918): Error loading forms containing countdown-widget
 - [#7933](https://github.com/medic/cht-core/issues/7933): Error 500 when processing SMS message missing year from Bikram Sambat aggregate
 
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Gareth Bowen](https://github.com/garethbowen)
+- [Diana Barsan](https://github.com/dianabarsan)
+

--- a/content/en/core/releases/4.1.0.md
+++ b/content/en/core/releases/4.1.0.md
@@ -72,3 +72,17 @@ None.
 - [#7862](https://github.com/medic/cht-core/issues/7862): Use the right palette variables across webapp
 - [#7878](https://github.com/medic/cht-core/issues/7878): Create base for wdio mobile e2e automation and automate bulk delete
 - [#7944](https://github.com/medic/cht-core/issues/7944): Staging URL placeholder replacement uses old `builds` database
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Ashley](https://github.com/mrjones-plip)
+- [elvisdorkenoo](https://github.com/elvisdorkenoo)
+- [Gareth Bowen](https://github.com/garethbowen)
+- [Diana Barsan](https://github.com/dianabarsan)
+- [Jennifer Q](https://github.com/latin-panda)
+- [Mokhtar](https://github.com/m5r)
+- [Andra Blaj](https://github.com/andrablaj)
+

--- a/content/en/core/releases/4.1.0.md
+++ b/content/en/core/releases/4.1.0.md
@@ -78,7 +78,7 @@ None.
 
 Thanks to all who committed changes for this release!
 
-- [Ashley](https://github.com/mrjones-plip)
+- [mrjones](https://github.com/mrjones-plip)
 - [elvisdorkenoo](https://github.com/elvisdorkenoo)
 - [Gareth Bowen](https://github.com/garethbowen)
 - [Diana Barsan](https://github.com/dianabarsan)

--- a/content/en/core/releases/4.1.1.md
+++ b/content/en/core/releases/4.1.1.md
@@ -29,3 +29,12 @@ None.
 
 - [#8110](https://github.com/medic/cht-core/issues/8110): E2E test failing when next year is leap year
 - [#8112](https://github.com/medic/cht-core/issues/8112): Integration E2E test failing when next year is leap year 
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Gareth Bowen](https://github.com/garethbowen)
+- [Andra Blaj](https://github.com/andrablaj)
+- [Diana Barsan](https://github.com/dianabarsan)
+

--- a/content/en/core/releases/4.1.2.md
+++ b/content/en/core/releases/4.1.2.md
@@ -25,3 +25,12 @@ None.
 
 - [#8173](https://github.com/medic/cht-core/issues/8173): API Changes watcher skips changes - or becomes blocked
 - [#8205](https://github.com/medic/cht-core/issues/8205): Nginx can't connect to API after container restarts because of dynamic IP allocation
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Diana Barsan](https://github.com/dianabarsan)
+- [Gareth Bowen](https://github.com/garethbowen)
+

--- a/content/en/core/releases/4.2.0.md
+++ b/content/en/core/releases/4.2.0.md
@@ -171,7 +171,7 @@ Thanks to all who committed changes for this release!
 
 - [Samuel I.](https://github.com/samuelimoisili)
 - [Gareth Bowen](https://github.com/garethbowen)
-- [Ashley](https://github.com/mrjones-plip)
+- [mrjones](https://github.com/mrjones-plip)
 - [Diana Barsan](https://github.com/dianabarsan)
 - [Tatiana Lépiz](https://github.com/tatilepizs)
 - [Marc Abbyad](https://github.com/abbyad)

--- a/content/en/core/releases/4.2.0.md
+++ b/content/en/core/releases/4.2.0.md
@@ -163,3 +163,24 @@ None.
 - [#8151](https://github.com/medic/cht-core/issues/8151): E2E builds fail for external contributors because of allure history jobs
 - [#8099](https://github.com/medic/cht-core/issues/8099): Enable easy integration with certbot and nginx container
 - [#8024](https://github.com/medic/cht-core/issues/8024): Update scalability suite to work with 4.x
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Samuel I.](https://github.com/samuelimoisili)
+- [Gareth Bowen](https://github.com/garethbowen)
+- [Ashley](https://github.com/mrjones-plip)
+- [Diana Barsan](https://github.com/dianabarsan)
+- [Tatiana Lépiz](https://github.com/tatilepizs)
+- [Marc Abbyad](https://github.com/abbyad)
+- [Jennifer Q](https://github.com/latin-panda)
+- [Joshua Kuestersteffen](https://github.com/jkuester)
+- [Yuvraj Rimal](https://github.com/1yuv)
+- [Bede Ngaruko](https://github.com/ngaruko)
+- [Mokhtar](https://github.com/m5r)
+- [Andra Blaj](https://github.com/andrablaj)
+- [Lore](https://github.com/lorerod)
+- [Kenn Sippell](https://github.com/kennsippell)
+

--- a/content/en/core/releases/4.2.1.md
+++ b/content/en/core/releases/4.2.1.md
@@ -24,3 +24,13 @@ None.
 ### Improvements
 
 - [#8214](https://github.com/medic/cht-core/issues/8214): Align nginx and ALB timeout values
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Diana Barsan](https://github.com/dianabarsan)
+- [Jennifer Q](https://github.com/latin-panda)
+- [Gareth Bowen](https://github.com/garethbowen)
+

--- a/content/en/core/releases/4.2.2.md
+++ b/content/en/core/releases/4.2.2.md
@@ -26,3 +26,13 @@ None.
 - [#8161](https://github.com/medic/cht-core/issues/8161): Telemetry doc metadata.versions.app is `unknown` for all telemetry docs
 - [#8359](https://github.com/medic/cht-core/issues/8359): Infinite scrolling not working on Contacts tab
 
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Diana Barsan](https://github.com/dianabarsan)
+- [Jennifer Q](https://github.com/latin-panda)
+- [Gareth Bowen](https://github.com/garethbowen)
+

--- a/content/en/core/releases/4.2.3.md
+++ b/content/en/core/releases/4.2.3.md
@@ -28,3 +28,13 @@ None.
 ### Technical improvements
 
 - [#8558](https://github.com/medic/cht-core/issues/8558): Skip Protractor e2e tests suites on old supported branches
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Diana Barsan](https://github.com/dianabarsan)
+- [Jennifer Q](https://github.com/latin-panda)
+- [Gareth Bowen](https://github.com/garethbowen)
+

--- a/content/en/core/releases/4.3.0.md
+++ b/content/en/core/releases/4.3.0.md
@@ -115,3 +115,26 @@ A new API endpoint now allows exporting API request performance. The output is f
 - [#8404](https://github.com/medic/cht-core/issues/8404): Flaky test: API changes feed should respond to changes even after services are restarted
 - [#8412](https://github.com/medic/cht-core/issues/8412): Flaky test: Submit a death report Should verify that the counter for the Deaths was updated.
 - [#8420](https://github.com/medic/cht-core/issues/8420): Flaky test: ongoing replication "before all" hook for ongoing replication
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Kenn Sippell](https://github.com/kennsippell)
+- [Jennifer Q](https://github.com/latin-panda)
+- [Diana Barsan](https://github.com/dianabarsan)
+- [Tatiana Lépiz](https://github.com/tatilepizs)
+- [Bede Ngaruko](https://github.com/ngaruko)
+- [Gareth Bowen](https://github.com/garethbowen)
+- [Lore](https://github.com/lorerod)
+- [Ashley](https://github.com/mrjones-plip)
+- [Njuguna Ndung'u](https://github.com/njogz)
+- [Michael Kohn](https://github.com/michaelkohn)
+- [Joshua Kuestersteffen](https://github.com/jkuester)
+- [Binod Adhikary](https://github.com/binokaryg)
+- [Jonathan](https://github.com/jonathanbataire)
+- [Yuvraj Rimal](https://github.com/1yuv)
+- [Prajwol Shrestha](https://github.com/PrjShrestha)
+- [Henok](https://github.com/henokgetachew)
+

--- a/content/en/core/releases/4.3.0.md
+++ b/content/en/core/releases/4.3.0.md
@@ -128,7 +128,7 @@ Thanks to all who committed changes for this release!
 - [Bede Ngaruko](https://github.com/ngaruko)
 - [Gareth Bowen](https://github.com/garethbowen)
 - [Lore](https://github.com/lorerod)
-- [Ashley](https://github.com/mrjones-plip)
+- [mrjones](https://github.com/mrjones-plip)
 - [Njuguna Ndung'u](https://github.com/njogz)
 - [Michael Kohn](https://github.com/michaelkohn)
 - [Joshua Kuestersteffen](https://github.com/jkuester)

--- a/content/en/core/releases/4.3.1.md
+++ b/content/en/core/releases/4.3.1.md
@@ -24,3 +24,14 @@ None.
 ### Bug fixes
 
 - [#8478](https://github.com/medic/cht-core/issues/8478): Invalid phone for patient still running triggers
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Prajwol Shrestha](https://github.com/PrjShrestha)
+- [Gareth Bowen](https://github.com/garethbowen)
+- [Jennifer Q](https://github.com/latin-panda)
+- [Diana Barsan](https://github.com/dianabarsan)
+

--- a/content/en/core/releases/4.4.0.md
+++ b/content/en/core/releases/4.4.0.md
@@ -131,7 +131,7 @@ None.
 
 Thanks to all who committed changes for this release!
 
-- [Ashley](https://github.com/mrjones-plip)
+- [mrjones](https://github.com/mrjones-plip)
 - [Diana Barsan](https://github.com/dianabarsan)
 - [Gareth Bowen](https://github.com/garethbowen)
 - [Prajwol Shrestha](https://github.com/PrjShrestha)

--- a/content/en/core/releases/4.4.0.md
+++ b/content/en/core/releases/4.4.0.md
@@ -125,3 +125,20 @@ None.
 - [#8533](https://github.com/medic/cht-core/issues/8533): Ignore unimportant step failures in CI build
 
 
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Ashley](https://github.com/mrjones-plip)
+- [Diana Barsan](https://github.com/dianabarsan)
+- [Gareth Bowen](https://github.com/garethbowen)
+- [Prajwol Shrestha](https://github.com/PrjShrestha)
+- [Joshua Kuestersteffen](https://github.com/jkuester)
+- [Jennifer Q](https://github.com/latin-panda)
+- [Daniel](https://github.com/nydr)
+- [Bede Ngaruko](https://github.com/ngaruko)
+- [Kenn Sippell](https://github.com/kennsippell)
+- [Tatiana Lépiz](https://github.com/tatilepizs)
+

--- a/content/en/core/releases/4.4.1.md
+++ b/content/en/core/releases/4.4.1.md
@@ -26,3 +26,13 @@ None.
 - [#7670](https://github.com/medic/cht-core/issues/7670): Same patient id assigned to multiple patients in a same instance
 - [#8576](https://github.com/medic/cht-core/issues/8576): Low performance in Reports tab for users with thousands of places
 - [#8589](https://github.com/medic/cht-core/issues/8589): Users unable to edit the report they created
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Jennifer Q](https://github.com/latin-panda)
+- [Gareth Bowen](https://github.com/garethbowen)
+- [Diana Barsan](https://github.com/dianabarsan)
+

--- a/content/en/core/releases/4.4.2.md
+++ b/content/en/core/releases/4.4.2.md
@@ -27,3 +27,11 @@ None.
 
 - [#8745](https://github.com/medic/cht-core/issues/8745): error.loading.form.no_authorized when opening a form from tasks tab because context evaluates to false
 
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Diana Barsan](https://github.com/dianabarsan)
+

--- a/content/en/core/releases/4.5.0.md
+++ b/content/en/core/releases/4.5.0.md
@@ -100,3 +100,24 @@ None.
 - [#8692](https://github.com/medic/cht-core/issues/8692): Flaky e2e test: Default navigation hamburger menu spec failing: Hamburger Menu tests "before all" hook
 
 
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Tatiana Lépiz](https://github.com/tatilepizs)
+- [Jennifer Q](https://github.com/latin-panda)
+- [sauln](https://github.com/fardarter)
+- [Gareth Bowen](https://github.com/garethbowen)
+- [Joshua Kuestersteffen](https://github.com/jkuester)
+- [Ashley](https://github.com/mrjones-plip)
+- [njuguna-n](https://github.com/njuguna-n)
+- [Diana Barsan](https://github.com/dianabarsan)
+- [Bede Ngaruko](https://github.com/ngaruko)
+- [Darío Hereñú](https://github.com/kant)
+- [Samuel I.](https://github.com/samuelimoisili)
+- [Yuvraj Rimal](https://github.com/1yuv)
+- [Ben Kiarie](https://github.com/Benmuiruri)
+- [Lore](https://github.com/lorerod)
+

--- a/content/en/core/releases/4.5.0.md
+++ b/content/en/core/releases/4.5.0.md
@@ -111,7 +111,7 @@ Thanks to all who committed changes for this release!
 - [sauln](https://github.com/fardarter)
 - [Gareth Bowen](https://github.com/garethbowen)
 - [Joshua Kuestersteffen](https://github.com/jkuester)
-- [Ashley](https://github.com/mrjones-plip)
+- [mrjones](https://github.com/mrjones-plip)
 - [njuguna-n](https://github.com/njuguna-n)
 - [Diana Barsan](https://github.com/dianabarsan)
 - [Bede Ngaruko](https://github.com/ngaruko)

--- a/content/en/core/releases/4.5.1.md
+++ b/content/en/core/releases/4.5.1.md
@@ -27,3 +27,12 @@ None.
 
 - [#8745](https://github.com/medic/cht-core/issues/8745): error.loading.form.no_authorized when opening a form from tasks tab because context evaluates to false
 
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Diana Barsan](https://github.com/dianabarsan)
+- [Jennifer Q](https://github.com/latin-panda)
+

--- a/content/en/core/releases/4.5.2.md
+++ b/content/en/core/releases/4.5.2.md
@@ -27,3 +27,11 @@ None.
 
 - [#8837](https://github.com/medic/cht-core/issues/8837): Telemetry date not logged on telemetry documents
 
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Jennifer Q](https://github.com/latin-panda)
+

--- a/content/en/core/releases/4.6.0.md
+++ b/content/en/core/releases/4.6.0.md
@@ -138,7 +138,7 @@ Thanks to all who committed changes for this release!
 
 - [Lore](https://github.com/lorerod)
 - [Gareth Bowen](https://github.com/garethbowen)
-- [Ashley](https://github.com/mrjones-plip)
+- [mrjones](https://github.com/mrjones-plip)
 - [Ben Kiarie](https://github.com/Benmuiruri)
 - [Tatiana Lépiz](https://github.com/tatilepizs)
 - [Joshua Kuestersteffen](https://github.com/jkuester)

--- a/content/en/core/releases/4.6.0.md
+++ b/content/en/core/releases/4.6.0.md
@@ -130,3 +130,23 @@ Performance of CHT forms has been significantly improved! Particularly, large fo
 - [#8800](https://github.com/medic/cht-core/pull/8800): Add nyc test coverage for API and Sentinel
 - [#8808](https://github.com/medic/cht-core/pull/8808): Add an explanation message to 2 assertions in  `routing.spec.js`
 - [#8811](https://github.com/medic/cht-core/pull/8811): Add coverage to all shared libs tests
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Lore](https://github.com/lorerod)
+- [Gareth Bowen](https://github.com/garethbowen)
+- [Ashley](https://github.com/mrjones-plip)
+- [Ben Kiarie](https://github.com/Benmuiruri)
+- [Tatiana Lépiz](https://github.com/tatilepizs)
+- [Joshua Kuestersteffen](https://github.com/jkuester)
+- [Henok](https://github.com/henokgetachew)
+- [Diana Barsan](https://github.com/dianabarsan)
+- [Mokhtar](https://github.com/m5r)
+- [Jennifer Q](https://github.com/latin-panda)
+- [Fred](https://github.com/freddieptf)
+- [Daniel](https://github.com/nydr)
+- [Sugat Bajracharya](https://github.com/sugat009)
+

--- a/content/en/core/releases/4.7.0.md
+++ b/content/en/core/releases/4.7.0.md
@@ -109,3 +109,26 @@ None.
 - [#8982](https://github.com/medic/cht-core/issues/8982): Update to Angular 17
 - [#9035](https://github.com/medic/cht-core/issues/9035): GitHub artifact being overwritten due to naming collision for minimum browser e2e tests 
 - [#9042](https://github.com/medic/cht-core/issues/9042): Upgrade CI workflow fails with image rate limit
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Yuvraj Rimal](https://github.com/1yuv)
+- [Diana Barsan](https://github.com/dianabarsan)
+- [Jennifer Q](https://github.com/latin-panda)
+- [Tatiana Lépiz](https://github.com/tatilepizs)
+- [Gareth Bowen](https://github.com/garethbowen)
+- [Ashley](https://github.com/mrjones-plip)
+- [Daniel](https://github.com/nydr)
+- [Mokhtar](https://github.com/m5r)
+- [yuv](https://github.com/1yrr)
+- [Ben Kiarie](https://github.com/Benmuiruri)
+- [Andra Blaj](https://github.com/andrablaj)
+- [Sheila Abby](https://github.com/SheilaAbby)
+- [ChinHairSaintClair](https://github.com/ChinHairSaintClair)
+- [Lore](https://github.com/lorerod)
+- [sauln](https://github.com/fardarter)
+- [Joshua Kuestersteffen](https://github.com/jkuester)
+

--- a/content/en/core/releases/4.7.1.md
+++ b/content/en/core/releases/4.7.1.md
@@ -28,3 +28,11 @@ None.
 ### Technical improvements
 
 None.
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Diana Barsan](https://github.com/dianabarsan)
+

--- a/content/en/core/releases/4.8.0.md
+++ b/content/en/core/releases/4.8.0.md
@@ -89,7 +89,7 @@ Thanks to all who committed changes for this release!
 - [Gareth Bowen](https://github.com/garethbowen)
 - [Daniel](https://github.com/nydr)
 - [Joshua Kuestersteffen](https://github.com/jkuester)
-- [Ashley](https://github.com/mrjones-plip)
+- [mrjones](https://github.com/mrjones-plip)
 - [Fred](https://github.com/freddieptf)
 - [Ben Kiarie](https://github.com/Benmuiruri)
 - [Lore](https://github.com/lorerod)

--- a/content/en/core/releases/4.8.0.md
+++ b/content/en/core/releases/4.8.0.md
@@ -78,3 +78,19 @@ None.
 - [#9113](https://github.com/medic/cht-core/issues/9113): Add a build step to validate PR titles conform to commitlint standard
 
 
+
+
+## Contributors
+
+Thanks to all who committed changes for this release!
+
+- [Jennifer Q](https://github.com/latin-panda)
+- [Diana Barsan](https://github.com/dianabarsan)
+- [Gareth Bowen](https://github.com/garethbowen)
+- [Daniel](https://github.com/nydr)
+- [Joshua Kuestersteffen](https://github.com/jkuester)
+- [Ashley](https://github.com/mrjones-plip)
+- [Fred](https://github.com/freddieptf)
+- [Ben Kiarie](https://github.com/Benmuiruri)
+- [Lore](https://github.com/lorerod)
+


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

This PR uses a [hacked version](https://github.com/medic/cht-core/blob/mrjones-hack-get-contributors-only/scripts/release-notes/index.js) of the new release note script to back-fill contributors on all 4.x versions except `4.2.4` and `4.3.2` which have some weird error that I don't want to chase down.

We shouldn't merge the  [ephemeral branch](https://github.com/medic/cht-core/blob/mrjones-hack-get-contributors-only/scripts/release-notes/index.js) `mrjones-hack-get-contributors-only`  on CHT Core repo, but published it for posterity.

the output of the bash wrapper [script used](https://github.com/medic/cht-core/blob/mrjones-hack-get-contributors-only/scripts/release-notes/get.contributors.sh) script `get.contributors.sh`:

```
./get.contributors.sh
saving version 4.0.0 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.0.0.md
saving version 4.0.1 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.0.1.md
saving version 4.1.0 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.1.0.md
saving version 4.1.1 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.1.1.md
saving version 4.1.2 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.1.2.md
saving version 4.2.0 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.2.0.md
saving version 4.2.1 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.2.1.md
saving version 4.2.2 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.2.2.md
saving version 4.2.3 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.2.3.md
saving version 4.2.4 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.2.4.md
Error: Could not find milestone with the repo cht-core and name 4.2.4
    at getMilestoneNumber (/home/mrjones/Documents/MedicMobile/cht-core/scripts/release-notes/index.js:175:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async getIssues (/home/mrjones/Documents/MedicMobile/cht-core/scripts/release-notes/index.js:285:27)
    at async Promise.all (index 0)
saving version 4.3.0 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.3.0.md
saving version 4.3.1 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.3.1.md
saving version 4.3.2 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.3.2.md
Error: Could not find milestone with the repo cht-core and name 4.3.2
    at getMilestoneNumber (/home/mrjones/Documents/MedicMobile/cht-core/scripts/release-notes/index.js:175:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async getIssues (/home/mrjones/Documents/MedicMobile/cht-core/scripts/release-notes/index.js:285:27)
    at async Promise.all (index 0)
saving version 4.4.0 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.4.0.md
saving version 4.4.1 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.4.1.md
saving version 4.4.2 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.4.2.md
saving version 4.5.0 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.5.0.md
saving version 4.5.1 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.5.1.md
saving version 4.5.2 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.5.2.md
saving version 4.6.0 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.6.0.md
saving version 4.7.0 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.7.0.md
saving version 4.7.1 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.7.1.md
saving version 4.8.0 to /home/mrjones/Documents/MedicMobile/cht-docs/content/en/core/releases/4.8.0.md
```

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

