### PR TITLE
fix(#1374): migrate navbar toggle menu to bootstrap 5

### DIFF
--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -7,14 +7,14 @@
     {{ if not .Site.Params.ui.sidebar_search_disable -}}
     <form class="td-sidebar__search d-flex align-items-center">
         {{ partial "search-input.html" . }}
-        <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-section-nav" aria-expanded="false" aria-label="Toggle section navigation">
+        <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-bs-toggle="collapse" data-bs-target="#td-section-nav" aria-controls="td-section-nav" aria-expanded="false" aria-label="Toggle section navigation">
         </button>
     </form>
     {{ else -}}
     <div id="content-mobile">
         <form class="td-sidebar__search d-flex align-items-center">
             {{ partial "search-input.html" . }}
-            <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-section-nav" aria-expanded="false" aria-label="Toggle section navigation">
+            <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-bs-toggle="collapse" data-bs-target="#td-section-nav" aria-controls="td-section-nav" aria-expanded="false" aria-label="Toggle section navigation">
             </button>
         </form>
     </div>


### PR DESCRIPTION
# Description
Migrates data-toggle to data-bs-toggle and data-target to data-bs-target to fix the hamburger menu on smaller screens.
Fixes #1374.

# License
The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

