### PR TITLE
core: add the env variable run the upgrade tests locally

### DIFF
--- a/content/en/contribute/code/core/automated-tests.md
+++ b/content/en/contribute/code/core/automated-tests.md
@@ -183,6 +183,7 @@ To run the upgrade e2e tests in your local environment, follow these steps:
     - `export MARKET_URL_READ=https://staging.dev.medicmobile.org`.
     - `export STAGING_SERVER=_couch/builds_4`.
     - `export BRANCH=<your branch name>`.
+    - `export BASE_VERSION=<base version>`(it can be used `latest` as the value).
 - Run the upgrade e2e tests: `npm run upgrade-wdio`
 
 If you experience errors such as:


### PR DESCRIPTION
# Description

Add an extra environment variable (`BASE_VERSION`) to be able to execute successfully the upgrade tests locally


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

