### PR TITLE
feat: add doc for disabling SONAR rule preventing TODO comments

### DIFF
--- a/content/en/contribute/code/static-analysis.md
+++ b/content/en/contribute/code/static-analysis.md
@@ -176,6 +176,9 @@ Java:
       - `threshold` 7 -> 4
     - [`S3776`](https://rules.sonarsource.com/javascript/RSPEC-3776/) - Cognitive Complexity of functions should not be too high
       - `threshold` 15 -> 5
+  - Disabled
+      - [`S1135`](https://rules.sonarsource.com/javascript/RSPEC-1135/) - Track uses of "TODO" tags
+          - Disabled because we typically use "TODO" tags to mark code as needing future updates which cannot be currently applied for reasons outside our direct control (e.g. requiring a dependency uplift).
 
 JavaScript:
 
@@ -186,6 +189,8 @@ JavaScript:
       - [`S3776`](https://rules.sonarsource.com/javascript/RSPEC-3776/) - Cognitive Complexity of functions should not be too high
          - `threshold` 15 -> 5
    - Disabled
+       - [`S1135`](https://rules.sonarsource.com/javascript/RSPEC-1135/) - Track uses of "TODO" tags
+           - Disabled because we typically use "TODO" tags to mark code as needing future updates which cannot be currently applied for reasons outside our direct control (e.g. requiring a dependency uplift).
       - [`S2699`](https://rules.sonarsource.com/javascript/RSPEC-2699/) - Tests should include assertions
          - Disabled due of rigidity of the rule when detecting `expect` imports and calls to imported functions that have assertions
 
@@ -197,6 +202,9 @@ Python:
          - `threshold` 7 -> 4
       - [`S3776`](https://rules.sonarsource.com/javascript/RSPEC-3776/) - Cognitive Complexity of functions should not be too high
          - `threshold` 15 -> 5
+   - Disabled
+       - [`S1135`](https://rules.sonarsource.com/javascript/RSPEC-1135/) - Track uses of "TODO" tags
+           - Disabled because we typically use "TODO" tags to mark code as needing future updates which cannot be currently applied for reasons outside our direct control (e.g. requiring a dependency uplift).
 
 TypeScript:
 
@@ -206,3 +214,6 @@ TypeScript:
          - `threshold` 7 -> 4
       - [`S3776`](https://rules.sonarsource.com/javascript/RSPEC-3776/) - Cognitive Complexity of functions should not be too high
          - `threshold` 15 -> 5
+   - Disabled
+       - [`S1135`](https://rules.sonarsource.com/javascript/RSPEC-1135/) - Track uses of "TODO" tags
+           - Disabled because we typically use "TODO" tags to mark code as needing future updates which cannot be currently applied for reasons outside our direct control (e.g. requiring a dependency uplift).


### PR DESCRIPTION
# Description

[RSPEC-1135](https://rules.sonarsource.com/javascript/RSPEC-1135/) prevents adding any `TODO` comments to the code base. The idea is to guard against merging unfinished code, but in reality, this is not much of a danger since those situations are easily identified via code review.  

Instead, this rule is preventing use from using `TODO` comments to mark places in the code that will need updated in the future (but cannot be updated as a part of the current project).  I think the benefits are not worth the downsides and we should just disable this rule.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

