### PR TITLE
Update Android documentation for Google Play signed app domain verification

### DIFF
--- a/content/en/apps/guides/android/branding.md
+++ b/content/en/apps/guides/android/branding.md
@@ -264,12 +264,12 @@ For apps signed by Google Play, you need to use the SHA256 fingerprint provided 
 #### Steps to Retrieve SHA256 Fingerprint from Google Play
 
 1. **Log in to Google Play Console**.
-2. **Navigate to Your App**: Select your app from the list of published applications.
-3. **Setup > App Signing**: In the left-hand menu, under the Setup Menu, there is App Signing.
-4. **Find SHA256 Fingerprint**: Google Play will display the SHA256 fingerprint required for your app.
+2. **Navigate to your app**: Select your app from the list of published applications.
+3. **Setup > App signing**: In the left-hand menu, under the Setup Menu, there is App Signing.
+4. **Find SHA256 fingerprint**: Google Play will display the SHA256 fingerprint required for your app.
 5. **Update assetlinks.json**: Use this SHA256 fingerprint in your `assetlinks.json` file. (Google Play also provides the full JSON)
 
-Once added and pushed to the server, the deep link can be monitored from the console as well, under the **Deep Links** in the left-hand menu where the Play Console allows you to check the deep link settings and also provides hints to fix any errors (providing the right SHA256 Fingerprint to add).
+Once added and pushed to the server, the deep link can be monitored from the console as well, under the **Deep Links** in the left-hand menu where the Play Console allows you to check the deep link settings and also provides hints to fix any errors (providing the right SHA256 fingerprint to add).
 
 ### Verifying it works
 

--- a/content/en/apps/guides/android/branding.md
+++ b/content/en/apps/guides/android/branding.md
@@ -267,7 +267,7 @@ For apps signed by Google Play, you need to use the SHA256 fingerprint provided 
 2. **Navigate to Your App**: Select your app from the list of published applications.
 3. **Setup > App Signing**: In the left-hand menu, under the Setup Menu, there is App Signing.
 4. **Find SHA256 Fingerprint**: Google Play will display the SHA256 fingerprint required for your app.
-5. **Update assetlinks.json**: Use this SHA256 fingerprint in your `assetlinks.json` file.
+5. **Update assetlinks.json**: Use this SHA256 fingerprint in your `assetlinks.json` file. (Google Play also provides the full JSON)
 
 Once added and pushed to the server, the deep link can be monitored from the console as well, under the **Deep Links** in the left-hand menu where the Play Console allows you to check the deep link settings and also provides hints to fix any errors (providing the right SHA256 Fingerprint to add).
 

--- a/content/en/apps/guides/android/branding.md
+++ b/content/en/apps/guides/android/branding.md
@@ -257,6 +257,20 @@ All you have to do to make the CHT serve your assetlinks at `/.well-known/assetl
    ```
 3. Set the cert fingerprint in the [`assetlinks` configuration]({{< ref "apps/reference/app-settings/assetlinks" >}}) for your CHT instance and deploy it to your server with cht-conf.
 
+#### Note for Apps Using Google Play Signing
+
+For apps signed by Google Play, you need to use the SHA256 fingerprint provided in the Google Play Console to ensure successful domain verification.
+
+#### Steps to Retrieve SHA256 Fingerprint from Google Play
+
+1. **Log in to Google Play Console**.
+2. **Navigate to Your App**: Select your app from the list of published applications.
+3. **Setup > App Signing**: In the left-hand menu, under the Setup Menu, there is App Signing.
+4. **Find SHA256 Fingerprint**: Google Play will display the SHA256 fingerprint required for your app.
+5. **Update assetlinks.json**: Use this SHA256 fingerprint in your `assetlinks.json` file.
+
+Once added and pushed to the server, the deep link can be monitored from the console as well, under the **Deep Links** in the left-hand menu where the Play Console allows you to check the deep link settings and also provides hints to fix any errors (providing the right SHA256 Fingerprint to add).
+
 ### Verifying it works
 
 There are different ways to verify your setup works and we'll go through a few of them in the next steps.


### PR DESCRIPTION
# Description

For apps distributed through the Play Store using Google Play Console signing, domain verification fails even after adding the SHA256 fingerprint used to build the app.

This PR updates the CHT Android Flavors documentation to include detailed instructions for apps signed by Google Play. Specifically, it addresses the need to use the SHA256 fingerprint provided by the Google Play Console for successful domain verification.

# Importance

These updates are crucial for ensuring that apps signed by Google Play are correctly associated with their respective domains, allowing for seamless deep linking and improved user experience.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

