### PR TITLE
Fix deprecated values

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -51,7 +51,7 @@ id = "G-98W4V2NTPJ"
 # Language configuration
 
 [languages]
-[languages.en]
+[languages.en.params]
 title = "Community Health Toolkit"
 description = "Digital health initiatives in the hardest-to-reach areas"
 languageName ="English"

--- a/content/en/contribute/code/cht-conf.md
+++ b/content/en/contribute/code/cht-conf.md
@@ -15,7 +15,7 @@ description: >
 
 ### Operating System Specific
 
-{{< tabpane persistLang=false lang=shell >}}
+{{< tabpane persist=false lang=shell >}}
 {{< tab header="Linux (Ubuntu)" >}}
 npm install -g cht-conf
 sudo python -m pip install git+https://github.com/medic/pyxform.git@medic-conf-1.17#egg=pyxform-medic


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Fix deprecated values of persistLang and language.en:

> ERROR deprecated: config: languages.en.description: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.127.0. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
ERROR deprecated: config: languages.en.time_format_default: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.127.0. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
ERROR deprecated: config: languages.en.time_format_blog: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.127.0. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
Watching for changes in /Users/esthermoturi/Documents/GitHub/cht-docs/{assets,content,layouts,package.json,static}
Watching for config changes in /Users/esthermoturi/Documents/GitHub/cht-docs/config.toml, /Users/esthermoturi/Documents/GitHub/cht-docs/go.mod
Start building sites … 
hugo v0.126.3+extended darwin/arm64 BuildDate=2024-06-02T13:02:43Z VendorInfo=brew

> WARN  Shortcode "tabpane" parameter `persistLang` is deprecated, use `persist` instead: "/Users/esthermoturi/Documents/GitHub/cht-docs/content/en/contribute/code/cht-conf.md:18:1"


