### PR TITLE
feat: update known Enketo issues for 4.x upgrade

### DIFF
--- a/content/en/apps/guides/updates/preparing-for-4.md
+++ b/content/en/apps/guides/updates/preparing-for-4.md
@@ -218,7 +218,7 @@ After pushing your app config (see "CHT Conf" above), you can proceed to go thro
 
 ##### Active
 
-* [A regression](https://github.com/medic/cht-core/issues/8225) added in `4.6.0`, causes the [contact selector functionality](https://docs.communityhealthtoolkit.org/apps/guides/forms/form-inputs/#contact-selector) to not work as expected when loading contact data into the `inputs` group _when the group is non-relevant._ More details, including a viable workaround, are documented on the linked issue.
+* [A regression](https://github.com/medic/cht-core/issues/8225) added in `4.6.0`, causes the [contact selector functionality](https://docs.communityhealthtoolkit.org/apps/guides/forms/form-inputs/#contact-selector) to not work as expected when loading contact data into the `inputs` group _when the group is non-relevant._ More details, including a viable workaround, are documented on the  [issue](https://github.com/medic/cht-core/issues/8225).
 
 ##### Resolved
 

--- a/content/en/apps/guides/updates/preparing-for-4.md
+++ b/content/en/apps/guides/updates/preparing-for-4.md
@@ -216,9 +216,17 @@ After pushing your app config (see "CHT Conf" above), you can proceed to go thro
 
 #### Known issues
 
+##### Active
+
+* [A regression](https://github.com/medic/cht-core/issues/8225) added in `4.6.0`, causes the [contact selector functionality](https://docs.communityhealthtoolkit.org/apps/guides/forms/form-inputs/#contact-selector) to not work as expected when loading contact data into the `inputs` group _when the group is non-relevant._ More details, including a viable workaround, are documented on the linked issue.
+
+##### Resolved
+
 * The answer to a non-relevant question [is not immediately cleared](https://github.com/medic/cht-core/issues/7674) when the question becomes non-relevant and is still provided to XPath expressions that reference the question. When the form is submitted, the non-relevant answers will be cleared and any dependent XPath expressions will be re-evaluated.
     * This behavior applies both to questions that were answered and later became non-relevant as well as to questions which have configured default values.
+    * This issue was resolved in CHT `4.6.0` and so only affects versions `4.0` - `4.5`. 
 * In `3.x` versions of the CHT you could simulate a _bulleted list_ in a form label (e.g. a `note`) by using `-` or `*`. Now, in `4.x`, the bullets are no longer properly displayed in the label due to [this bug](https://github.com/medic/cht-core/issues/8002). 
+    * This issue was resolved in CHT `4.6.0` and so only affects versions `4.0` - `4.5`.
 
 #### Community cht-upgrade-helper
 


### PR DESCRIPTION
# Description

We still have partners upgrading from `3.x` to `4.x`, so the Upgrade Prep guide remains relevant documentation.  However, there are some changes to the "Known issues" with Enekto in the more recent versions of `4.x` (which are likely the versions that partners will be upgrading to).  

This PR updates the docs around the known Enketo issues with the goal of providing useful and relevant information to partners currently trying to prepare for an upgrade.  

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

