### PR TITLE
docs: add the required permission when using a fine-grained access token for cht-pipeline

### DIFF
--- a/content/en/apps/guides/data/analytics/environment-variables.md
+++ b/content/en/apps/guides/data/analytics/environment-variables.md
@@ -34,6 +34,3 @@ All the variables in the `.env` file:
 {{% alert title="Note" %}}
 If `CHT_PIPELINE_BRANCH_URL` is pointing to a private GitHub repository, you'll need an access token in the URL. Assuming your repository is `medic/cht-pipeline`, you would replace  `<PAT>`  with an access token: `https://<PAT>@github.com/medic/cht-pipeline.git#main`. Please see [GitHub's instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) on how to generate a token. If you create a fine-grained access token you need to provide read and write access to the [contents](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#repository-permissions-for-contents) of the repository.
 {{% /alert %}}
-
-{{% alert title="Note" %}}
-{{% /alert %}}

--- a/content/en/apps/guides/data/analytics/environment-variables.md
+++ b/content/en/apps/guides/data/analytics/environment-variables.md
@@ -32,5 +32,8 @@ All the variables in the `.env` file:
 | `COUCHDB_SECURE`          | `false`                                               | Is connection to CouchDB instance secure?                                                                                                  |
 
 {{% alert title="Note" %}}
-If `CHT_PIPELINE_BRANCH_URL` is pointing to a private GitHub repository, you'll need an access token in the URL. Assuming your repository is `medic/cht-pipeline`, you would replace  `<PAT>`  with an access token: `https://<PAT>@github.com/medic/cht-pipeline.git#main`. Please see [GitHub's instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) on how to generate a token.
+If `CHT_PIPELINE_BRANCH_URL` is pointing to a private GitHub repository, you'll need an access token in the URL. Assuming your repository is `medic/cht-pipeline`, you would replace  `<PAT>`  with an access token: `https://<PAT>@github.com/medic/cht-pipeline.git#main`. Please see [GitHub's instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) on how to generate a token. If you create a fine-grained access token you need to provide read and write access to the [contents](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#repository-permissions-for-contents) of the repository.
+{{% /alert %}}
+
+{{% alert title="Note" %}}
 {{% /alert %}}


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Add the required permission when using a fin-grained Github Personal Access Token for cht-pipeline

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

