### PR TITLE
feat: update docker image to have proper Hugo version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-hugo extended_0.122.0
+hugo extended_0.122.0 # Should match the version in compose.yml
 golang 1.21.0
 nodejs 16.20.2

--- a/compose.yml
+++ b/compose.yml
@@ -3,9 +3,9 @@ version: '3'
 services:
   hugo:
     container_name: cht-hugo
-    image: jakejarvis/hugo-extended:0.113.0 # note that 0.122 isn't avail, but 0.113 has everything we need for now
+    image: docker.io/hugomods/hugo:0.122.0 # Should match the version in .tool-versions
     ports:
       - 1313:1313
     volumes:
       - ./:/src
-    command: server --buildDrafts --buildFuture --bind 0.0.0.0
+    command: hugo server --buildDrafts --buildFuture --bind 0.0.0.0


### PR DESCRIPTION
# Description

The `jakejarvis/hugo-extended` is unmaintained (as is the `klakegg/hugo` which I have also used).  Instead, there is a different [community maintained image](https://discourse.gohugo.io/t/the-up-to-date-hugo-docker-images/43293).  

I am honestly a bit mystified by the terrible SEO for `hugomods/hugo`.  Just from the pull counts it is orders of magnitude more popular than other images, but does not surface at the top in the results list on Docker Hub or in a DuckDuckGo search....

It looks like the [base versions of the image](https://docker.hugomods.com/docs/tags/#latest) contain what we need!  (Extended + Go + Node...). Might be able to get away with one of the more specific ones, but not sure how useful it is to get super picky about the size of a docker image for development usage... :sweat_smile: 

I based the compose.yml updates the [documented compose config](https://docker.hugomods.com/docs/development/docker-compose/).  

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

