### PR TITLE
remove deprecated services line from compose file

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   hugo:
     container_name: cht-hugo


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

fixes this error on `docker compose up`:

```
WARN[0000] /home/mrjones/Documents/MedicMobile/cht-docs/compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

