### PR TITLE
App Dev Hosting: work work manual steps, move docker helper to the top

### DIFF
--- a/content/en/hosting/4.x/app-developer.md
+++ b/content/en/hosting/4.x/app-developer.md
@@ -27,26 +27,50 @@ docker kill $(docker ps -q)
 After meeting these requirements, create a directory and download the developer YAML files in the directory you want to store them. This example uses `~/cht-4-app-developer` as the directory:
 
 ```shell 
-mkdir  ~/cht-4-app-developer && cd ~/cht-4-app-developer
-curl -s -o docker-compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
-curl -s -o cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-core.yml
-curl -s -o cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-couchdb.yml
+
+mkdir -p ~/cht_4_app_developer-dir/{compose,couchdb} && cd ~/cht_4_app_developer-dir
+curl -s -o ./compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
+curl -s -o ./compose/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-core.yml
+curl -s -o ./compose/cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-couchdb.yml
 ```
 
-You should now have 3 compose files which we can check with `ls`:
+You should now have 3 compose files and 2 directories which we can check with `ls -R`:
 
 ```shell
-ls
-cht-core.yml  cht-couchdb.yml  docker-compose.yml
+ls -R
+compose  compose.yml  couch
+
+./compose:
+cht-core.yml  cht-couchdb.yml
+
+./couch:
 ```
 
-To start the first developer CHT instance, run `docker-compose`, prepending the needed environment variables:
+To prepare for the first developer CHT instance, write all environment variables to the `.env` file with this code:
+
+```sh
+cat > ~/cht_4_app_developer-dir/.env << EOF
+NGINX_HTTP_PORT=8080
+NGINX_HTTPS_PORT=8443
+COUCHDB_USER=medic
+COUCHDB_PASSWORD=password
+CHT_COMPOSE_PROJECT_NAME=cht_4_app_developer
+DOCKER_CONFIG_PATH=${HOME}/cht_4_app_developer-dir
+COUCHDB_SECRET=19f3b9fb1d7aba1ef4d1c5ed709512ee
+COUCHDB_UUID=e7122b1e463de4449fb05b0c494b0224
+COUCHDB_DATA=${HOME}/cht_4_app_developer-dir/couch
+CHT_COMPOSE_PATH=${HOME}/cht_4_app_developer-dir/compose
+CHT_NETWORK=cht_4_app_developer
+EOF
+```
+
+Start the first CHT instance by calling `docker`:
 
 ```shell script
-CHT_COMPOSE_PROJECT_NAME=app-devl COUCHDB_SECRET=foo DOCKER_CONFIG_PATH=${PWD} COUCHDB_DATA=${PWD}/couchd CHT_COMPOSE_PATH=${PWD} COUCHDB_USER=medic COUCHDB_PASSWORD=password docker-compose up
+cd ~/cht_4_app_developer-dir && docker compose up
 ```
 
-This may take some minutes to fully start depending on the speed of the internet connection and speed of the host. This is because docker needs to download all the storage layers for all the containers and the CHT needs to run the first run set up. After downloads and setup has completed, the CHT should be accessible on [https://localhost](https://localhost). You can log in with username `medic` and password `password`.
+This may take some minutes to fully start depending on the speed of the internet connection and speed of the host. This is because docker needs to download all the storage layers for all the containers and the CHT needs to run the first run set up. After downloads and setup has completed, the CHT should be accessible on [https://localhost:8443](https://localhost:8443). You can log in with username `medic` and password `password`.
 
 When connecting to a new dev CHT instance for the first time, an error will be shown, "Your connection is not private" with `NET::ERR_CERT_AUTHORITY_INVALID` (see [screenshot](/apps/tutorials/local-setup/privacy.error.png)). To get past this, click "Advanced" and then click "Proceed to localhost".
 
@@ -61,52 +85,44 @@ After running the first instance of the CHT, it's easy to run as many more as ar
 Assuming you want to start a new project called `the_second` and  start the instance on `HTTP` port `8081` and `HTTPS` port `8443`, we would first create a new directory and download the same files:
 
 ```shell 
-mkdir  ~/the_second && cd ~/the_second
-curl -s -o docker-compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
-curl -s -o cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-core.yml
-curl -s -o cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-couchdb.yml
+mkdir -p ~/cht_4_app_developer-2nd-dir/{compose,couchdb} && cd ~/cht_4_app_developer-2nd-dir
+curl -s -o ./compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
+curl -s -o ./compose/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-core.yml
+curl -s -o ./compose/cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-couchdb.yml
 ```
 
+Then, we would create an `.env` file like before
 
-Then, we would use the same `docker-compose` command as above, but this time specify the ports:
+```sh
+cat > ~/cht_4_app_developer-2nd-dir/.env << EOF
+NGINX_HTTP_PORT=8081
+NGINX_HTTPS_PORT=8444
+COUCHDB_USER=medic
+COUCHDB_PASSWORD=password
+CHT_COMPOSE_PROJECT_NAME=cht_4_app_developer-2nd
+DOCKER_CONFIG_PATH=${HOME}/cht_4_app_developer-2nd-dir
+COUCHDB_SECRET=19f3b9fb1d7aba1ef4d1c5ed709512ee
+COUCHDB_UUID=e7122b1e463de4449fb05b0c494b0224
+COUCHDB_DATA=${HOME}/cht_4_app_developer-2nd-dir/couch
+CHT_COMPOSE_PATH=${HOME}/cht_4_app_developer-2nd-dir/compose
+CHT_NETWORK=cht_4_app_developer-2nd
+EOF
+```
+
+And finally use the same `docker compose` command as above:
 
 ```shell script
-NGINX_HTTP_PORT=8081 NGINX_HTTPS_PORT=8444 CHT_COMPOSE_PROJECT_NAME=app-devl COUCHDB_SECRET=foo DOCKER_CONFIG_PATH=${PWD} COUCHDB_DATA=${PWD}/couchd CHT_COMPOSE_PATH=${PWD} COUCHDB_USER=medic COUCHDB_PASSWORD=password docker-compose up
+cd ~/cht_4_app_developer-2nd-dir && docker compose up
 ```
 
 The second instance is now accessible at  [https://localhost:8444](https://localhost:8444) and again using username `medic` and password `password` to login.
 
-## The `.env` file
-
-Often times it's convenient to use revision control, like GitHub, to store and publish changes in a CHT app.  A nice compliment to this is to store the specifics on how to run the `docker-compose` command for each app. By using a shared `docker-compose` configuration for all developers on the same app, it avoids any port collisions and enables all developers to have a unified configuration.
-
-Using the above `the_second` sample project, we can create a file `~/the_second/.env` with this contents:
-
-```shell
-NGINX_HTTP_PORT=8081 
-NGINX_HTTPS_PORT=8444 
-CHT_COMPOSE_PROJECT_NAME=second 
-COUCHDB_SECRET=foo 
-DOCKER_CONFIG_PATH=./
-COUCHDB_DATA=./couchd 
-CHT_COMPOSE_PATH=./
-COUCHDB_USER=medic 
-COUCHDB_PASSWORD=password
-```
-
-Now it's easy to boot this environment:
-
-```shell
-cd ~/the_second
-docker-compose up
-```
-
 ## Switching & concurrent projects
 
-The easiest way to switch between projects is to stop the first set of containers and start the second set. Cancel the first project running in the foreground with `ctrl + c` and `stop` all the project's services:
+The easiest way to switch between projects is to stop the first set of containers and start the second set. Cancel the first project running in the foreground with `ctrl + c` and `stop` all the project's services. Here any container named `cht_4_app_developer-2nd*` is stopped:
 
 ```shell
-docker stop second_api_1 second_cht-upgrade-service_1 second_couchdb_1 second_haproxy_1 second_healthcheck_1 second_nginx_1 second_sentinel_1
+docker stop $(docker ps -q --filter "name=cht_4_app_developer-2nd*")
 ```
 
 Alternately, you can stop ALL containers (even non-CHT ones!) with `docker kill $(docker ps -q)`. Then start the other CHT project using either the `.env` file or use the explicit command with ports and other environment variables as shown above.

--- a/content/en/hosting/4.x/app-developer.md
+++ b/content/en/hosting/4.x/app-developer.md
@@ -18,139 +18,32 @@ To deploy the CHT 3.x in production, see either [AWS hosting]({{< relref "hostin
 
 ## Getting started
 
-Be sure to meet the [CHT hosting requirements]({{< relref "hosting/requirements" >}}) first. To avoid conflicts, ensure that all other CHT 4.x instances are stopped. To stop ALL containers, you can use
+First, decide which way to run the CHT: Docker Helper or manually it via `docker compose`. Since they both achieve the same result, **it is recommended to use Docker Helper** as shown in the next section as it's very easy to run.  Alternately, the manual process is covered at the [bottom of the page](#manual-docker-compose-method).  
 
-```shell
-docker kill $(docker ps -q)
-````
-
-After meeting these requirements, create a directory and download the developer YAML files in the directory you want to store them. This example uses `~/cht-4-app-developer` as the directory:
-
-```shell 
-
-mkdir -p ~/cht_4_app_developer-dir/{compose,couchdb} && cd ~/cht_4_app_developer-dir
-curl -s -o ./compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
-curl -s -o ./compose/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-core.yml
-curl -s -o ./compose/cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-couchdb.yml
-```
-
-You should now have 3 compose files and 2 directories which we can check with `ls -R`:
-
-```shell
-ls -R
-compose  compose.yml  couch
-
-./compose:
-cht-core.yml  cht-couchdb.yml
-
-./couch:
-```
-
-To prepare for the first developer CHT instance, write all environment variables to the `.env` file with this code:
-
-```sh
-cat > ~/cht_4_app_developer-dir/.env << EOF
-NGINX_HTTP_PORT=8080
-NGINX_HTTPS_PORT=8443
-COUCHDB_USER=medic
-COUCHDB_PASSWORD=password
-CHT_COMPOSE_PROJECT_NAME=cht_4_app_developer
-DOCKER_CONFIG_PATH=${HOME}/cht_4_app_developer-dir
-COUCHDB_SECRET=19f3b9fb1d7aba1ef4d1c5ed709512ee
-COUCHDB_UUID=e7122b1e463de4449fb05b0c494b0224
-COUCHDB_DATA=${HOME}/cht_4_app_developer-dir/couch
-CHT_COMPOSE_PATH=${HOME}/cht_4_app_developer-dir/compose
-CHT_NETWORK=cht_4_app_developer
-EOF
-```
-
-Start the first CHT instance by calling `docker`:
-
-```shell script
-cd ~/cht_4_app_developer-dir && docker compose up
-```
-
-This may take some minutes to fully start depending on the speed of the internet connection and speed of the host. This is because docker needs to download all the storage layers for all the containers and the CHT needs to run the first run set up. After downloads and setup has completed, the CHT should be accessible on [https://localhost:8443](https://localhost:8443). You can log in with username `medic` and password `password`.
-
-When connecting to a new dev CHT instance for the first time, an error will be shown, "Your connection is not private" with `NET::ERR_CERT_AUTHORITY_INVALID` (see [screenshot](/apps/tutorials/local-setup/privacy.error.png)). To get past this, click "Advanced" and then click "Proceed to localhost".
-
-## Running the Nth CHT instance
-
-After running the first instance of the CHT, it's easy to run as many more as are needed.  This is achieved by specifying different:
-
-* port for `HTTP` redirects (`CHT_HTTP`)
-* port for `HTTPS` traffic (`NGINX_HTTP_PORT`)
-* directory for storing the compose files and CouchDB files
-
-Assuming you want to start a new project called `the_second` and  start the instance on `HTTP` port `8081` and `HTTPS` port `8443`, we would first create a new directory and download the same files:
-
-```shell 
-mkdir -p ~/cht_4_app_developer-2nd-dir/{compose,couchdb} && cd ~/cht_4_app_developer-2nd-dir
-curl -s -o ./compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
-curl -s -o ./compose/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-core.yml
-curl -s -o ./compose/cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-couchdb.yml
-```
-
-Then, we would create an `.env` file like before
-
-```sh
-cat > ~/cht_4_app_developer-2nd-dir/.env << EOF
-NGINX_HTTP_PORT=8081
-NGINX_HTTPS_PORT=8444
-COUCHDB_USER=medic
-COUCHDB_PASSWORD=password
-CHT_COMPOSE_PROJECT_NAME=cht_4_app_developer-2nd
-DOCKER_CONFIG_PATH=${HOME}/cht_4_app_developer-2nd-dir
-COUCHDB_SECRET=19f3b9fb1d7aba1ef4d1c5ed709512ee
-COUCHDB_UUID=e7122b1e463de4449fb05b0c494b0224
-COUCHDB_DATA=${HOME}/cht_4_app_developer-2nd-dir/couch
-CHT_COMPOSE_PATH=${HOME}/cht_4_app_developer-2nd-dir/compose
-CHT_NETWORK=cht_4_app_developer-2nd
-EOF
-```
-
-And finally use the same `docker compose` command as above:
-
-```shell script
-cd ~/cht_4_app_developer-2nd-dir && docker compose up
-```
-
-The second instance is now accessible at  [https://localhost:8444](https://localhost:8444) and again using username `medic` and password `password` to login.
-
-## Switching & concurrent projects
-
-The easiest way to switch between projects is to stop the first set of containers and start the second set. Cancel the first project running in the foreground with `ctrl + c` and `stop` all the project's services. Here any container named `cht_4_app_developer-2nd*` is stopped:
-
-```shell
-docker stop $(docker ps -q --filter "name=cht_4_app_developer-2nd*")
-```
-
-Alternately, you can stop ALL containers (even non-CHT ones!) with `docker kill $(docker ps -q)`. Then start the other CHT project using either the `.env` file or use the explicit command with ports and other environment variables as shown above.
-
-To run projects concurrently open a second terminal and start the second project so you don't have to cancel and `stop` the first project.  Remember to avoid port conflicts!
 
 ## CHT Docker Helper for 4.x
 
 {{% alert title="Note" %}} This is for CHT 4.x.  To use a CHT 3.x version, see the earlier [CHT Docker Helper page]({{< relref "hosting/3.x/app-developer#cht-docker-helper" >}}){{% /alert %}}
 
-The `cht-docker-compose.sh` scripts downloads 3 compose files and builds an `.env` file used above. This greatly eases starting your first CHT instance with a simple text based GUI which works on Windows (WSL2), macOS (both x86 and Apple Silicon) and Linux.
+The `cht-docker-compose.sh` scripts downloads 3 compose files and builds an `.env` file. This greatly eases starting your first CHT instance with a simple text based GUI which works on Windows (WSL2), macOS (both x86 and Apple Silicon) and Linux.
 
 ![The cht-docker-compose.sh script showing the URL and version of the CHT instance as well as number of containers launched, global container count, medic images downloaded count and OS load average. Finally a "Successfully started my_first_project" message is shown and denotes the login is "medic" and the password is "password".](cht-docker-helper.png)
 
 This script brings a lot of benefits with it:
 * You only have to download one bash script
 * All compose files and images will be downloaded automatically for you
-* All networks, storage volumes and containers will be created 
+* All networks, storage volumes and containers will be created
 * A valid TLS certificate will be installed, allowing you to easily test on with CHT Android natively on a mobile device
 * An unused port is automatically chosen for you when creating a new project.  No more manually looking at your existing `.env` files!
 
 ### Installing
 
 To get started using it:
-1. Clone the [CHT Core](https://github.com/medic/cht-core/) repo
-2. When you want to check for updates, just run `git pull origin` in the `cht-core` directory.
+1. Meet all [CHT hosting requirements]({{< relref "hosting/requirements" >}})
+2. Clone the [CHT Core](https://github.com/medic/cht-core/) repo
+3. When you want to check for updates, just run `git pull origin` in the `cht-core` directory.
 
-If you want a more stand-alone version, you can `curl` the bash script directly, but you can't use `git` to easily update it then:
+An alternate to steps 2 and 3 above, if a more stand-alone version is desired, the bash script can be `curl`ed directly, but you can't use `git` to easily update it then:
 
 ```shell
 curl -s -o cht-docker-compose.sh https://raw.githubusercontent.com/medic/cht-core/master/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -290,15 +183,128 @@ If just container name is shown above, a fresh local-ip.medicmobile.org certific
 
 The bash script keeps files in two places:
 
-* **`*.env` files** -  the same directory as the bash script. 
+* **`*.env` files** -  the same directory as the bash script.
 * **`~/medic/cht-docker/` files** - in your home directory, a sub-directory is created for each project.  Within each project directory, a `compose` directory has the two compose files and the `couch` directory has the CouchDB datafiles.
 
 While you can manually remove any of these, it's best to use the `destroy` command above to ensure all related data files are deleted too.
 
-### Video 
+### Video
 
 Here is a video of the helper being run on 1 Dec 2022. The video references `lazydocker` which is [a great way](https://github.com/jesseduffield/lazydocker) to monitor and control your local docker environment:
 
 {{< youtube hrcy8JlJP9M >}}
 
--------
+## Manual `docker compose` method
+
+This process achieves the same result as Docker Helper, but is a more manual process. Be sure the [CHT hosting requirements]({{< relref "hosting/requirements" >}}) are all met first.
+
+To avoid conflicts, ensure that all other CHT 4.x instances are stopped. To stop ALL containers, you can use
+
+```shell
+docker kill $(docker ps -q)
+````
+
+After meeting these requirements, create a directory and download the developer YAML files in the directory you want to store them. This example uses `~/cht-4-app-developer` as the directory:
+
+```shell 
+
+mkdir -p ~/cht_4_app_developer-dir/{compose,couchdb} && cd ~/cht_4_app_developer-dir
+curl -s -o ./compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
+curl -s -o ./compose/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-core.yml
+curl -s -o ./compose/cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-couchdb.yml
+```
+
+You should now have 3 compose files and 2 directories which we can check with `ls -R`:
+
+```shell
+ls -R
+compose  compose.yml  couch
+
+./compose:
+cht-core.yml  cht-couchdb.yml
+
+./couch:
+```
+
+To prepare for the first developer CHT instance, write all environment variables to the `.env` file with this code:
+
+```sh
+cat > ~/cht_4_app_developer-dir/.env << EOF
+NGINX_HTTP_PORT=8080
+NGINX_HTTPS_PORT=8443
+COUCHDB_USER=medic
+COUCHDB_PASSWORD=password
+CHT_COMPOSE_PROJECT_NAME=cht_4_app_developer
+DOCKER_CONFIG_PATH=${HOME}/cht_4_app_developer-dir
+COUCHDB_SECRET=19f3b9fb1d7aba1ef4d1c5ed709512ee
+COUCHDB_UUID=e7122b1e463de4449fb05b0c494b0224
+COUCHDB_DATA=${HOME}/cht_4_app_developer-dir/couch
+CHT_COMPOSE_PATH=${HOME}/cht_4_app_developer-dir/compose
+CHT_NETWORK=cht_4_app_developer
+EOF
+```
+
+Start the first CHT instance by calling `docker`:
+
+```shell script
+cd ~/cht_4_app_developer-dir && docker compose up
+```
+
+This may take some minutes to fully start depending on the speed of the internet connection and speed of the host. This is because docker needs to download all the storage layers for all the containers and the CHT needs to run the first run set up. After downloads and setup has completed, the CHT should be accessible on [https://localhost:8443](https://localhost:8443). You can log in with username `medic` and password `password`.
+
+When connecting to a new dev CHT instance for the first time, an error will be shown, "Your connection is not private" with `NET::ERR_CERT_AUTHORITY_INVALID` (see [screenshot](/apps/tutorials/local-setup/privacy.error.png)). To get past this, click "Advanced" and then click "Proceed to localhost".
+
+## Running the Nth CHT instance
+
+After running the first instance of the CHT, it's easy to run as many more as are needed.  This is achieved by specifying different:
+
+* port for `HTTP` redirects (`CHT_HTTP`)
+* port for `HTTPS` traffic (`NGINX_HTTP_PORT`)
+* directory for storing the compose files and CouchDB files
+
+Assuming you want to start a new project called `the_second` and  start the instance on `HTTP` port `8081` and `HTTPS` port `8443`, we would first create a new directory and download the same files:
+
+```shell 
+mkdir -p ~/cht_4_app_developer-2nd-dir/{compose,couchdb} && cd ~/cht_4_app_developer-2nd-dir
+curl -s -o ./compose.yml https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
+curl -s -o ./compose/cht-core.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-core.yml
+curl -s -o ./compose/cht-couchdb.yml https://staging.dev.medicmobile.org/_couch/builds_4/medic%3Amedic%3Amaster/docker-compose/cht-couchdb.yml
+```
+
+Then, we would create an `.env` file like before
+
+```sh
+cat > ~/cht_4_app_developer-2nd-dir/.env << EOF
+NGINX_HTTP_PORT=8081
+NGINX_HTTPS_PORT=8444
+COUCHDB_USER=medic
+COUCHDB_PASSWORD=password
+CHT_COMPOSE_PROJECT_NAME=cht_4_app_developer-2nd
+DOCKER_CONFIG_PATH=${HOME}/cht_4_app_developer-2nd-dir
+COUCHDB_SECRET=19f3b9fb1d7aba1ef4d1c5ed709512ee
+COUCHDB_UUID=e7122b1e463de4449fb05b0c494b0224
+COUCHDB_DATA=${HOME}/cht_4_app_developer-2nd-dir/couch
+CHT_COMPOSE_PATH=${HOME}/cht_4_app_developer-2nd-dir/compose
+CHT_NETWORK=cht_4_app_developer-2nd
+EOF
+```
+
+And finally use the same `docker compose` command as above:
+
+```shell script
+cd ~/cht_4_app_developer-2nd-dir && docker compose up
+```
+
+The second instance is now accessible at  [https://localhost:8444](https://localhost:8444) and again using username `medic` and password `password` to login.
+
+## Switching & concurrent projects
+
+The easiest way to switch between projects is to stop the first set of containers and start the second set. Cancel the first project running in the foreground with `ctrl + c` and `stop` all the project's services. Here any container named `cht_4_app_developer-2nd*` is stopped:
+
+```shell
+docker stop $(docker ps -q --filter "name=cht_4_app_developer-2nd*")
+```
+
+Alternately, you can stop ALL containers (even non-CHT ones!) with `docker kill $(docker ps -q)`. Then start the other CHT project using either the `.env` file or use the explicit command with ports and other environment variables as shown above.
+
+To run projects concurrently open a second terminal and start the second project so you don't have to cancel and `stop` the first project.  Remember to avoid port conflicts!


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

* update the manual app dev to be more like [prod docker](http://localhost:1313/hosting/4.x/self-hosting/single-node/) docs
* `docker-compose` -> `docker compose`
* always use `.env` files
* remove now redundant `.env` section
* move docker helper to be the top most section
* clearly call out that manual `docker compose` and Docker Helper achieve the same end result (as opposed to needing to run both)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

