### PR TITLE
Fix 23 bad links

### DIFF
--- a/content/en/building/guides/debugging/secure-sharing-of-developer-instance.md
+++ b/content/en/building/guides/debugging/secure-sharing-of-developer-instance.md
@@ -4,8 +4,6 @@ linkTitle: "Securely Sharing Your Development Environment"
 weight: 
 description: >
   Use a publicly accessible Linux web server to forward https requests to your development environment
-relatedContent: >
-  
 aliases:
    - /apps/guides/debugging/secure-sharing-of-developer-instance
 ---
@@ -21,7 +19,7 @@ Also not - if you only want to test with mobile devices that require a valid TLS
 ## Overview
 When using a local [development environment]({{< relref "contribute/code/core/dev-environment" >}}), you may want to share your work with other collaborators. By using a publicly accessible web server, you can receive the secure https requests and forward them back to your CHT instance which doesn't have https set up:
 
-[<img src="/apps/guides/debugging/images/SSH.tunnel.diagram.svg" width=100% height=100%>](/building/guides/debugging/images/SSH.tunnel.diagram.svg)
+[<img src="/building/guides/debugging/images/SSH.tunnel.diagram.svg" width=100% height=100%>](/building/guides/debugging/images/SSH.tunnel.diagram.svg)
 
 Once you have this web server set up, you may continue to use it whenever you want by simply reconnecting to it via the secure tunnel.
 

--- a/content/en/hosting/3.x/app-developer.md
+++ b/content/en/hosting/3.x/app-developer.md
@@ -34,7 +34,7 @@ docker-compose -f docker-compose-developer-3.x-only.yml up
 
 This may take some minutes to fully start depending on the speed of the Internet connection and speed of the bare-metal host. This is because docker needs to download all the storage layers for all the containers and the CHT needs to run the first run set up. After downloads and setup has completed, the CHT should be accessible on [https://localhost](https://localhost).
 
-When connecting to a new dev CHT instance for the first time, an error will be shown, "Your connection is not private" (see [screenshot](/building/tutorials/local-setup/privacy.error.png)). To get past this, click "Advanced" and then click "Proceed to localhost".
+When connecting to a new dev CHT instance for the first time, an error will be shown, "Your connection is not private" (see [screenshot](/building/local-setup/privacy.error.png)). To get past this, click "Advanced" and then click "Proceed to localhost".
 
 ## Running the Nth CHT instance
 

--- a/content/en/hosting/4.x/app-developer.md
+++ b/content/en/hosting/4.x/app-developer.md
@@ -252,7 +252,7 @@ cd ~/cht_4_app_developer-dir && docker compose up
 
 This may take some minutes to fully start depending on the speed of the internet connection and speed of the host. This is because docker needs to download all the storage layers for all the containers and the CHT needs to run the first run set up. After downloads and setup has completed, the CHT should be accessible on [https://localhost:8443](https://localhost:8443). You can log in with username `medic` and password `password`.
 
-When connecting to a new dev CHT instance for the first time, an error will be shown, "Your connection is not private" with `NET::ERR_CERT_AUTHORITY_INVALID` (see [screenshot](/building/tutorials/local-setup/privacy.error.png)). To get past this, click "Advanced" and then click "Proceed to localhost".
+When connecting to a new dev CHT instance for the first time, an error will be shown, "Your connection is not private" with `NET::ERR_CERT_AUTHORITY_INVALID` (see [screenshot](/building/local-setup/privacy.error.png)). To get past this, click "Advanced" and then click "Proceed to localhost".
 
 ## Running the Nth CHT instance
 


### PR DESCRIPTION
Fixed bad links ran on 22nd September 2024.

```
Run ./.github/scripts/muffet.sh
http://localhost:1313/hosting/3.x/app-developer/
	404	http://localhost:1313/building/tutorials/local-setup/privacy.error.png
http://localhost:1313/contribute/medic/onboarding/technical-resources/
	403	https://www.udacity.com/course/asynchronous-javascript-requests--ud109
	tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2024-09-22T03:26:42Z is after 2024-09-20T09:03:01Z	https://pouchdb.com/guides/
http://localhost:1313/hosting/4.x/app-developer/
	404	http://localhost:1313/building/tutorials/local-setup/privacy.error.png
http://localhost:1313/building/guides/debugging/secure-sharing-of-developer-instance/
	404	http://localhost:1313/apps/guides/debugging/images/SSH.tunnel.diagram.svg
http://localhost:1313/contribute/code/
	502	https://alpha.dev.medicmobile.org
http://localhost:1313/core/overview/architecture/
	tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2024-09-22T03:2[7](https://github.com/medic/cht-docs/commit/5654968442a2ad1bb3712c4e80c3e23e2f6a7544/checks#step:9:8):56Z is after 2024-09-20T09:03:01Z	https://pouchdb.com
http://localhost:1313/core/overview/offline-first/
	tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2024-09-22T03:2[8](https://github.com/medic/cht-docs/commit/5654968442a2ad1bb3712c4e80c3e23e2f6a7544/checks#step:9:9):10Z is after 2024-09-20T09:03:01Z	https://pouchdb.com/
Error: Process completed with exit code 1.
```
