### PR TITLE
fix(#1552): GH user link validation slack alerts come from

### DIFF
--- a/.github/workflows/cron-check-links.yml
+++ b/.github/workflows/cron-check-links.yml
@@ -3,6 +3,8 @@
 #  - If you bump one version up to latest, please bump them all so we stay current!
 #  - Hugo builds the site twice: once for link checking and once minified for pushing live
 #  - Bash script for muffet is intentionally stand alone so devs/content editors can easily run it locally
+# 
+# this line to hopefully fix medic/cht-docs/issues/1552
 
 
 # Scheduled workflows run on the latest commit on


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Fix which GH user link validation slack alerts come from per medic/cht-docs/issues/1552 . I think the last person to edit the CI is the GH user that slack shows.  Let's find out!

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

