### PR TITLE
chore(#1576): add clarity to training card guide

### DIFF
--- a/content/en/building/guides/training/training-cards-resources/_index.md
+++ b/content/en/building/guides/training/training-cards-resources/_index.md
@@ -14,7 +14,7 @@ aliases:
 
 ## Best practices
 
-If you are deploying new training cards, here are some best practices to follow: 
+If you are deploying new [trainings cards]({{< relref "building/features/training" >}}), here are some best practices to follow: 
 
 - When deploying training cards for the first time, provide guidance in advance as to what users should expect from the cards and how to use them
 - Test training card content with a small set of users to ensure learnability and understanding before deploying to your live instance
@@ -32,7 +32,7 @@ Some examples of data to monitor include:
 
 ## Examples
 
-Below is a list of [trainings cards]({{< relref "building/features/training" >}}) that you can use in your project to train users about new updates in CHT. Read the [step by step guide]({{< relref "building/guides/training/training-cards" >}}) to deploy the training cards.
+Below is a list of training cards that you can use in your project to train users about new updates in CHT. Read the [step by step guide]({{< relref "building/guides/training/training-cards" >}}) to deploy the training cards.
 
 ### Floating Action Button
 
@@ -57,3 +57,7 @@ Get the training card files [here](https://github.com/medic/cht-docs/tree/main/c
 {{< figure src="images/more-options.png" class="left col-10" >}}
 
 <br clear="all">
+
+Once you have downloaded the training card files, follow the [step by step guide]({{< relref "building/guides/training/training-cards" >}}) to learn how to edit the `properties file` to configure: 
+- The `roles` of users who can view the training cards 
+- The `start_date` to define the training start day (when the training cards should show)


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

- Moving the link to the training card feature page to the top to avoid navigating away in the example section
- Adding clarification that one needs to edit the example training card files with `role` and `start_date` in order to see them.

Closes #1576 

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

