### PR TITLE
Dynamic shell for autocomplete on k8s docs

### DIFF
--- a/content/en/contribute/code/core/deploy-on-eks.md
+++ b/content/en/contribute/code/core/deploy-on-eks.md
@@ -27,8 +27,8 @@ Be sure you have these tools installed and repos cloned:
 Both `helm` and `kubectl` have autocomplete libraries. For power users and beginners alike, it adds a lot of discoverability. This code is for `zsh`, but `bash`, `fish` and `powershell` are supported as well:
 
    ```shell
-   source <(kubectl completion zsh)
-   source <(helm completion zsh)
+   source <(kubectl completion "$(basename "$SHELL")")
+   source <(helm completion "$(basename "$SHELL")")
    ```
 
 See [helm](https://helm.sh/docs/helm/helm_completion_bash/) and [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#enable-shell-autocompletion) docs to automatically loading these on every new session.


### PR DESCRIPTION
Changes instructions and copy/paste code snippet to use the current shell for the autocomplete setup. This allows someone to run the code as documented without needing to change the shell value from zsh to whatever they are using (even though zsh is the correct answer ;) ).

