### PR TITLE
fix(na): fix link for api docs in 4.11 release, correct cursor number in API docs

### DIFF
--- a/content/en/building/reference/api.md
+++ b/content/en/building/reference/api.md
@@ -874,7 +874,7 @@ Content-Type: application/json; charset=utf-8
 }
 ```
 
-2. Get the first 3 people of type `person` by using cursor `0`.
+2. Get 3 people of type `person` by using cursor `0`.
 
 ```
 GET /api/v1/person?type=person&cursor=0&limit=3

--- a/content/en/building/reference/api.md
+++ b/content/en/building/reference/api.md
@@ -874,10 +874,10 @@ Content-Type: application/json; charset=utf-8
 }
 ```
 
-2. Get 3 people of type `person` by using cursor `1`.
+2. Get the first 3 people of type `person` by using cursor `0`.
 
 ```
-GET /api/v1/person?type=person&cursor=1&limit=3
+GET /api/v1/person?type=person&cursor=0&limit=3
 ```
 
 ```

--- a/content/en/building/reference/api.md
+++ b/content/en/building/reference/api.md
@@ -874,10 +874,10 @@ Content-Type: application/json; charset=utf-8
 }
 ```
 
-2. Get 3 people of type `person` by using cursor `0`.
+2. Get the second set of 100 people of type `person` by using cursor `100`.
 
 ```
-GET /api/v1/person?type=person&cursor=0&limit=3
+GET /api/v1/person?type=person&cursor=100&limit=100
 ```
 
 ```

--- a/content/en/core/releases/4.11.0.md
+++ b/content/en/core/releases/4.11.0.md
@@ -29,7 +29,7 @@ None.
 The CHT datasource API has been expanded to allow querying places and persons by contact type.
 
 ##### Details
-See more details in the [API docs](https://docs.communityhealthtoolkit.org/building/reference/api/#get-apiv1person).
+See more details in the [API docs]({{< relref "building/reference/api#get-apiv1person" >}}).
 
 ### Phone numbers are not required to be checked for duplicates
 Phone number fields can now be used without automatically checking for duplicates. This can be useful for workflows where users may share a phone or for any workflow where having duplicate phones is possible, and it's undesirable to check for duplicates.

--- a/content/en/core/releases/4.11.0.md
+++ b/content/en/core/releases/4.11.0.md
@@ -29,7 +29,7 @@ None.
 The CHT datasource API has been expanded to allow querying places and persons by contact type.
 
 ##### Details
-See more details in the [api docs](http://docs.communityhealthtoolkit.org/cht-datasource/).
+See more details in the [API docs](https://docs.communityhealthtoolkit.org/building/reference/api/#get-apiv1person).
 
 ### Phone numbers are not required to be checked for duplicates
 Phone number fields can now be used without automatically checking for duplicates. This can be useful for workflows where users may share a phone or for any workflow where having duplicate phones is possible, and it's undesirable to check for duplicates.


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

* fix link for api docs in 4.11 release
* we're zero based for person API pagination, start at 0 instead of 1

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

