### PR TITLE
add where clause to exclude null versions on telemetry

### DIFF
--- a/content/en/building/guides/updates/preparing-for-4.md
+++ b/content/en/building/guides/updates/preparing-for-4.md
@@ -39,6 +39,7 @@ FROM
 WHERE
 	doc#>>'{type}' = 'telemetry'  
 	AND doc#>>'{metadata,year}' = to_char(current_date, 'yyyy')
+	AND doc#>>'{device,deviceInfo,app,version}' is not null
 GROUP BY 
 	telemetry_month, cht_android_version	
 ORDER BY 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

avoids returning results in SQL for `null` versions in telemetry which we already do in the [2nd query](https://docs.communityhealthtoolkit.org/building/guides/updates/preparing-for-4/#users-in-need-of-upgrade)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

