### PR TITLE
fix: correct docs for contact-summary field `appliesIf`

### DIFF
--- a/content/en/building/contact-summary/contact-summary-templated.md
+++ b/content/en/building/contact-summary/contact-summary-templated.md
@@ -55,7 +55,7 @@ Each field that can be shown on a contact's profile is defined as an object in t
 | `width` | `integer` | The horizontal space for the field. Common values are 12 for full width, 6 for half width, or 3 for quarter width. Default 12. | no |
 | `translate` | `boolean` | Whether or not to translate the `value`. Defaults to false. | no |
 | `context` | `object` | When `translate: true` and `value` uses [translation variables](https://angular-translate.github.io/docs/#/guide/06_variable-replacement), this value should provide the translation variables. | no |
-| `appliesIf` | `function()` or `boolean` | Return true if the field should be shown. | no |
+| `appliesIf` | `function()` | Return `true` if the field should be shown, and `false` if it should be hidden. Default is `true`. | no |
 | `appliesToType` | `string[]` | Filters the contacts for which `appliesIf` will be evaluated. For example, `['person']` or `['clinic', 'health_center']`. It defaults to all types if it is not defined. | no |
 
 <!-- TODO: See [How to configure profile pages]() for an example.  -->


### PR DESCRIPTION
# Description

Currently the [contact-summary `fields` docs](https://docs.communityhealthtoolkit.org/building/contact-summary/contact-summary-templated/#contact-summarytemplatedjs-fields) indicate that the `appliesIf` property for a field could be:

> `function()` or `boolean`

However, checking the [actual code in cht-conf](https://github.com/medic/cht-conf/blame/da017f990c954950afb1235e90ca7ea6b2179d9a/src/contact-summary/contact-summary-emitter.js#L17), there is no way that a `boolean` value could be set here with a semantically logical meaning.  

```js
        if (!f.appliesIf || f.appliesIf()) {
```

If you set `appliesIf = false`, this if-statement would resolve `true` because `!false === true`.  If you set `appliesIf = true`, then we get the error `TypeError: f.appliesIf is not a function` because it will try to call `appliesIf` as a function when the property exists.

This PR simply updates the docs to clarify that `appliesIf` can _only_ be a function.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

