### PR TITLE
fix(#1737): change path muffet chmod and execute calls

### DIFF
--- a/.github/workflows/cron-check-links.yml
+++ b/.github/workflows/cron-check-links.yml
@@ -43,7 +43,8 @@ jobs:
         shell: bash
         run:  |
           chmod +x ./.github/scripts/*muffet*
-          ./.github/scripts/muffet.sh
+          cd .github/scripts
+          ./muffet.sh
 
       - name: Report errors to Slack, if any
         if: ${{ github.ref == 'refs/heads/main' && failure() }}

--- a/.github/workflows/cron-check-links.yml
+++ b/.github/workflows/cron-check-links.yml
@@ -42,9 +42,8 @@ jobs:
       - name: Run Muffet link checker
         shell: bash
         run:  |
-          cd .github/scripts/
-          chmod +x *muffet*
-          muffet.sh
+          chmod +x ./.github/scripts/*muffet*
+          ./.github/scripts/muffet.sh
 
       - name: Report errors to Slack, if any
         if: ${{ github.ref == 'refs/heads/main' && failure() }}


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

This PR fixes the path for muffet in CI.  Prior path was `muffet.sh` and needed to be `./muffet.sh`.  I went with a more explicit path `./.github/scripts/muffet.sh` which is what we were using before

hopefully will fix #1737

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

