### PR TITLE
fix(na): password change feature to be on 4.17 vs 4.16

### DIFF
--- a/content/en/building/concepts/access.md
+++ b/content/en/building/concepts/access.md
@@ -59,7 +59,7 @@ Users may log out by going to the options menu available in the top right corner
 
 ### Password reset on first login
 
-**Added in 4.16.0.**
+**Added in 4.17.0.**
 
 To enhance the security of CHT applications, users logging in for the first time, or who have had their password reset, are prompted to change the password provided by the system administrator to their own strong password.
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

We'd [just released](https://github.com/medic/cht-docs/pull/1711) the docs for the password change on first login feature which had it as being released in 4.16, but is currently [set for 4.17](https://github.com/medic/cht-core/milestone/140)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

