### PR TITLE
chore: order sections and move training page to Training section

### DIFF
--- a/content/en/building/_index.md
+++ b/content/en/building/_index.md
@@ -4,7 +4,7 @@ linkTitle: "Building"
 identifier: "Building"
 aliases:
     - /apps/
-weight: 3
+weight: 5
 description: >
   Overview and reference for building CHT Applications
 ---

--- a/content/en/building/training/training.md
+++ b/content/en/building/training/training.md
@@ -1,8 +1,11 @@
 ---
 title: "CHT training resources"
-linkTitle: "Training of End Users"
-weight : 1
+linkTitle: "Training CHT Users"
+weight : 4
+aliases:
+   - /running-programs/training
 ---
+
 ## CHT training process
 
 In the implementation of CHT supported community health programs, health care workers such as CHWs, CHW supervisors and facility based health care providers need training to help equip them with the required knowledge and skills to effectively carry out their roles and responsibilities. For most deployments, program leads and ministry of health officials may also need training for them to perform their roles, oversee and supervise the community health programs. End user training needs to be well planned and implemented using standardized training methods and approaches which take into account the capacity of end users. 

--- a/content/en/core/_index.md
+++ b/content/en/core/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "CHT Core Framework"
 linkTitle: "CHT Core Framework"
-weight: 4
+weight: 3
 description: >
   Technical overview and architecture of CHT Core used to build digital health applications
 ---

--- a/content/en/design/_index.md
+++ b/content/en/design/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Designing"
 linkTitle: "Designing"
-weight: 2
+weight: 4
 description: >
   Design guidelines for developers and designers of digital health applications
 ---


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

- Move the `CHT Core Framework` section before the `Designing` section.
- Move solitary `Training` page under the `Training` section.

Before:
![Screenshot 2025-01-31 at 17 00 58](https://github.com/user-attachments/assets/cd2cd52b-5730-4e34-9704-30b08a3d4e5b)

After:
![Screenshot 2025-01-31 at 17 01 05](https://github.com/user-attachments/assets/bad534b5-384b-4b30-89ee-4c91f49de9f0)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

