### PR TITLE
feat(#1782): documentation for cht-sync v2

### DIFF
--- a/content/en/hosting/analytics/building-dbt-models.md
+++ b/content/en/hosting/analytics/building-dbt-models.md
@@ -37,11 +37,17 @@ packages:
 ```
 To avoid breaking changes in downstream models, include `revision` in the dependency, which should be a version tag for `cht-pipeline`.
 
-In the CHT Sync config, set the URL of dbt GitHub repository to the `CHT_PIPELINE_BRANCH_URL` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}), either in `.env` if using Docker compose, or in `values.yaml` if using Kubernetes.
+For production and remote deployments, in the CHT Sync config, set the URL of the dbt GitHub repository to the `CHT_PIPELINE_BRANCH_URL` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}), either in `.env` if using Docker compose, or in `values.yaml` if using Kubernetes.
 
 {{% alert title="Note" %}}
 If `CHT_PIPELINE_BRANCH_URL` is pointing to a private GitHub repository, you'll need an access token in the URL. Assuming your repository is `medic/cht-pipeline`, you would replace  `<PAT>`  with an access token: `https://<PAT>@github.com/medic/cht-pipeline.git#main`. Please see [GitHub's instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) on how to generate a token. If you create a fine-grained access token you need to provide read and write access to the [contents](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#repository-permissions-for-contents) of the repository.
 {{% /alert %}}
+
+### Local development
+
+It is helpful to test changes locally before commiting them to a remote repository.
+For local testing and development, in the CHT Sync config, set the path to the dbt project to the `DBT_LOCAL_PATH` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}) in `.env`
+Use the [docker compose setup]({{< relref "hosting/analytics/setup-docker-compose" >}}) for CHT Sync with the `--local` profile.
 
 ### Deploying models
 
@@ -78,6 +84,7 @@ The name is configurable using the `POSTGRES_TABLE` environment variable.
 |`_id`|CouchDB's unique identifier of the record|
 |`saved_timestamp`| timestamp when this row was inserted|
 |`_deleted`| `true` if the document was deleted, `false` otherwise. |
+|`source`| The instance and database that this document was synced from. The format is `host/db`. |
 |`doc`| JSON of the source document|
 
 ### `document_metadata`
@@ -91,6 +98,8 @@ The document itself is not copied to this table; to use it requires joining to t
 |`saved_timestamp`|timestamp when this row was inserted|
 |`doc_type`|The general type of the document, see below|
 |`_deleted`| in this table, always `false`; rows which are copied with `_deleted = true` are immediately deleted  |
+|`instance`| The hostname of the CHT instance the document was synced from. |
+|`dbname`| The name of the CouchDB database the document was synced from. |
 
 ### `data_record`
 All form responses are stored in the `data_record` table; see more details [in the database schema conventions]({{< ref "core/overview/db-schema#reports" >}}).

--- a/content/en/hosting/analytics/building-dbt-models.md
+++ b/content/en/hosting/analytics/building-dbt-models.md
@@ -37,7 +37,7 @@ packages:
 ```
 To avoid breaking changes in downstream models, include `revision` in the dependency, which should be a version tag for `cht-pipeline`.
 
-For production and remote deployments, in the CHT Sync config, set the URL of the dbt GitHub repository to the `CHT_PIPELINE_BRANCH_URL` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}), either in `.env` if using Docker compose, or in `values.yaml` if using Kubernetes.
+In the CHT Sync config, set the URL of the dbt GitHub repository to the `CHT_PIPELINE_BRANCH_URL` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}), either in `.env` if using Docker compose, or in `values.yaml` if using Kubernetes.
 
 {{% alert title="Note" %}}
 If `CHT_PIPELINE_BRANCH_URL` is pointing to a private GitHub repository, you'll need an access token in the URL. Assuming your repository is `medic/cht-pipeline`, you would replace  `<PAT>`  with an access token: `https://<PAT>@github.com/medic/cht-pipeline.git#main`. Please see [GitHub's instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) on how to generate a token. If you create a fine-grained access token you need to provide read and write access to the [contents](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#repository-permissions-for-contents) of the repository.

--- a/content/en/hosting/analytics/building-dbt-models.md
+++ b/content/en/hosting/analytics/building-dbt-models.md
@@ -45,7 +45,7 @@ If `CHT_PIPELINE_BRANCH_URL` is pointing to a private GitHub repository, you'll 
 
 ### Local development
 
-When doing development, it  is convenient to be able to test changes locally with out needing to push to a remote repository and then have dbt pull those same changes back down. To expedite local development, set the `DBT_LOCAL_PATH` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}) to point to the dbt models directory on your computer.  Then, use the the `--local` profile [option]({{< relref "hosting/analytics/setup-docker-compose" >}}) when calling `docker` which avoids the `CHT_PIPELINE_BRANCH_URL` and uses the  `DBT_LOCAL_PATH` you just declared.
+When doing development, it is convenient to be able to test changes locally with out needing to push to a remote repository and then have dbt pull those same changes back down. To expedite local development, set the `DBT_LOCAL_PATH` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}) to point to the dbt models directory on your computer. Then, use the the `--local` profile [option]({{< relref "hosting/analytics/setup-docker-compose#local" >}}) when calling `docker` which avoids the `CHT_PIPELINE_BRANCH_URL` and uses the `DBT_LOCAL_PATH` you just declared.
 
 ### Deploying models
 

--- a/content/en/hosting/analytics/building-dbt-models.md
+++ b/content/en/hosting/analytics/building-dbt-models.md
@@ -45,7 +45,7 @@ If `CHT_PIPELINE_BRANCH_URL` is pointing to a private GitHub repository, you'll 
 
 ### Local development
 
-When doing development, it is convenient to be able to test changes locally with out needing to push to a remote repository and then have dbt pull those same changes back down. To expedite local development, set the `DBT_LOCAL_PATH` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}) to point to the dbt models directory on your computer. Then, use the the `--local` profile [option]({{< relref "hosting/analytics/setup-docker-compose#local" >}}) when calling `docker` which avoids the `CHT_PIPELINE_BRANCH_URL` and uses the `DBT_LOCAL_PATH` you just declared.
+When creating/modifying models, you can use the Docker [local profile]({{< relref "hosting/analytics/setup-docker-compose#local" >}}) to run a local test instance of CHT Sync that can reference your model configuration directly on your local machine (without needing to commit/push the changes remotely).
 
 ### Deploying models
 

--- a/content/en/hosting/analytics/building-dbt-models.md
+++ b/content/en/hosting/analytics/building-dbt-models.md
@@ -45,9 +45,7 @@ If `CHT_PIPELINE_BRANCH_URL` is pointing to a private GitHub repository, you'll 
 
 ### Local development
 
-It is helpful to test changes locally before commiting them to a remote repository.
-For local testing and development, in the CHT Sync config, set the path to the dbt project to the `DBT_LOCAL_PATH` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}) in `.env`
-Use the [docker compose setup]({{< relref "hosting/analytics/setup-docker-compose" >}}) for CHT Sync with the `--local` profile.
+When doing development, it  is convenient to be able to test changes locally with out needing to push to a remote repository and then have dbt pull those same changes back down. To expedite local development, set the `DBT_LOCAL_PATH` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}) to point to the dbt models directory on your computer.  Then, use the the `--local` profile [option]({{< relref "hosting/analytics/setup-docker-compose" >}}) when calling `docker` which avoids the `CHT_PIPELINE_BRANCH_URL` and uses the  `DBT_LOCAL_PATH` you just declared.
 
 ### Deploying models
 

--- a/content/en/hosting/analytics/environment-variables.md
+++ b/content/en/hosting/analytics/environment-variables.md
@@ -9,9 +9,10 @@ aliases:
    - /building/guides/data/analytics/environment-variables
 ---
 
-There are two environment variable groups in the `.env` file (if using Docker Compose), or in the `values.yaml` file (if using Kubernetes).
+There are three groups of environment variables. One for Postgres, one for CouchDB and one for DBT. These are found in the `.env` [file](https://github.com/medic/cht-sync/blob/main/env.template) and the `values.yaml` [file](https://github.com/medic/cht-sync/blob/main/deploy/cht_sync/values.yaml.template) for docker and Kubernetes respectively."
 1. `POSTGRES_`: Used by PostgreSQL to establish the PostgreSQL database to synchronize CouchDB data to. They define the schema and table names to store the CouchDB data, as well as where the tables and views for the models defined in `CHT_PIPELINE_BRANCH_URL` will be created. 
 2. `COUCHDB_`: Used by CouchDB to define the CouchDB instance to sync with. With `COUCHDB_DBS`, we can specify a list of databases to sync.
+3. `DBT_`: Used by dbt to pull from the remote `git` repository, declare sync frequency and concurrency. 
 
 | Name                      | Default                                               | Description                                                                                                                                |
 |---------------------------|-------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|

--- a/content/en/hosting/analytics/environment-variables.md
+++ b/content/en/hosting/analytics/environment-variables.md
@@ -9,7 +9,7 @@ aliases:
    - /building/guides/data/analytics/environment-variables
 ---
 
-There are three groups of environment variables. One for Postgres, one for CouchDB and one for DBT. These are found in the `.env` [file](https://github.com/medic/cht-sync/blob/main/env.template) and the `values.yaml` [file](https://github.com/medic/cht-sync/blob/main/deploy/cht_sync/values.yaml.template) for docker and Kubernetes respectively."
+There are three groups of environment variables. One for Postgres, one for CouchDB and one for DBT. These are found in the `.env` [file](https://github.com/medic/cht-sync/blob/main/env.template) and the `values.yaml` [file](https://github.com/medic/cht-sync/blob/main/deploy/cht_sync/values.yaml.template) for docker and Kubernetes respectively.
 1. `POSTGRES_`: Used by PostgreSQL to establish the PostgreSQL database to synchronize CouchDB data to. They define the schema and table names to store the CouchDB data, as well as where the tables and views for the models defined in `CHT_PIPELINE_BRANCH_URL` will be created. 
 2. `COUCHDB_`: Used by CouchDB to define the CouchDB instance to sync with. With `COUCHDB_DBS`, we can specify a list of databases to sync.
 3. `DBT_`: Used by dbt to pull from the remote `git` repository, declare sync frequency and concurrency. 

--- a/content/en/hosting/analytics/environment-variables.md
+++ b/content/en/hosting/analytics/environment-variables.md
@@ -9,11 +9,9 @@ aliases:
    - /building/guides/data/analytics/environment-variables
 ---
 
-There are two environment variable groups in the `.env` file (if using Docker Compose), or in the `values.yaml` file (if using Kubernetes). To successfully set up CHT Sync, it is important to understand the difference between them.
+There are two environment variable groups in the `.env` file (if using Docker Compose), or in the `values.yaml` file (if using Kubernetes).
 1. `POSTGRES_`: Used by PostgreSQL to establish the PostgreSQL database to synchronize CouchDB data to. They define the schema and table names to store the CouchDB data, as well as where the tables and views for the models defined in `CHT_PIPELINE_BRANCH_URL` will be created. 
 2. `COUCHDB_`: Used by CouchDB to define the CouchDB instance to sync with. With `COUCHDB_DBS`, we can specify a list of databases to sync.
-
-All the variables in the `.env` file:
 
 | Name                      | Default                                               | Description                                                                                                                                |
 |---------------------------|-------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
@@ -26,11 +24,15 @@ All the variables in the `.env` file:
 | `POSTGRES_HOST`           | `postgres`                                            | PostgreSQL instance                                                                                                                        |
 | `POSTGRES_PORT`           | `5432`                                                | PostgreSQL port  |
 | `CHT_PIPELINE_BRANCH_URL` | `"https://github.com/medic/cht-pipeline.git#main"`    | cht-pipeline branch containing the dbt models                                                                                            |
-| `DATAEMON_INTERVAL`       | `5`                                                   | Interval (in minutes) for looking for new changes in the CouchDB data                                                                      |
+| `DATAEMON_INTERVAL`       | `5`                                                   | Interval (in seconds) for looking for new changes in the CouchDB data                                                                      |
 | `COUCHDB_USER`            | `medic`                                               | Username of the CouchDB instance                                                                                             |
 | `COUCHDB_PASSWORD`        | `password`                                            | Password of the CouchDB instance                                                                                              |
 | `COUCHDB_DBS`             | `"medic"`                                             | Comma separated list of databases to sync e.g `"medic, medic_sentinel"`                                                                     |
 | `COUCHDB_HOST`            | `couchdb`                                             | Host of the CouchDB instance                                                                                                 |
 | `COUCHDB_PORT`            | `5984`                                                | Port of the CouchDB instance                                                                                                 |
-| `COUCHDB_SECURE`          | `false`                                               | Is connection to CouchDB instance secure?                                                                                                  |
+| `COUCHDB_SECURE`          | `false`                                               | Does the connection to CouchDB use HTTPS? |
+| `DBT_THREAD_COUNT`          | 1                                               | Number of threads per DBT process |
+| `DBT_BATCH_SIZE`          | 0                                               | Batch size for batched incremental runs |
+| `DBT_LOCAL_PATH`          |                                                | When running DBT locally for development, the path to the models directory on the host |
+| `DBT_SELECTOR`          | ''                                               | If using separate DBT processes, the select condition to select a subset of the models for a single dbt process. |
 

--- a/content/en/hosting/analytics/environment-variables.md
+++ b/content/en/hosting/analytics/environment-variables.md
@@ -32,8 +32,8 @@ There are three groups of environment variables. One for Postgres, one for Couch
 | `COUCHDB_HOST`            | `couchdb`                                             | Host of the CouchDB instance                                                                                                 |
 | `COUCHDB_PORT`            | `5984`                                                | Port of the CouchDB instance                                                                                                 |
 | `COUCHDB_SECURE`          | `false`                                               | Does the connection to CouchDB use HTTPS? |
-| `DBT_THREAD_COUNT`          | 1                                               | Number of threads per DBT process |
-| `DBT_BATCH_SIZE`          | 0                                               | Batch size for batched incremental runs |
+| `DBT_THREAD_COUNT`          | 1                                               | [Number of threads]({{< relref "hosting/analytics/tuning-dbt#threads" >}}) per DBT process |
+| `DBT_BATCH_SIZE`          | 0                                               | [Batch size]({{< relref "hosting/analytics/tuning-dbt#batching" >}}) for batched incremental runs |
 | `DBT_LOCAL_PATH`          |                                                | When running DBT locally for development, the path to the models directory on the host |
-| `DBT_SELECTOR`          | ''                                               | If using separate DBT processes, the select condition to select a subset of the models for a single dbt process. |
+| `DBT_SELECTOR`          | ''                                               | If using separate DBT processes, the [select condition]({{< relref "hosting/analytics/tuning-dbt#multiple-dbt-containers" >}}) to select a subset of the models for a single dbt process. |
 

--- a/content/en/hosting/analytics/setup-docker-compose.md
+++ b/content/en/hosting/analytics/setup-docker-compose.md
@@ -19,6 +19,7 @@ This guide will walk you through setting up a deployment of CHT Sync with the CH
 - [Current version](https://docs.docker.com/engine/install/) of `docker` or current version of [Docker Desktop](https://www.docker.com/products/docker-desktop/) both of which include `docker compose`. Note that the older `docker-compose` is [no longer supported](https://www.docker.com/blog/announcing-compose-v2-general-availability/).
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [cht-sync](https://github.com/medic/cht-sync) GitHub repository (can be cloned via `git clone https://github.com/medic/cht-sync`).
+- [A dbt project](https://docs.getdbt.com/docs/build/projects).
 
 ## Setup
 
@@ -43,9 +44,9 @@ The following profiles are available:
 
 This setup involves starting couch2pg, PostgreSQL, pgAdmin and dbt. It assumes you have a CouchDB instance running, and you updated the `.env` CouchDB variables accordingly. 
 
-When developing DBT models, it is helpful to test changes locally before committing them to a remote repository. To do this, set the path to the project to the `DBT_LOCAL_PATH` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}) in `.env`. You must set this to a valid directory where you have your CHT Pipeline models. You can not use `--local` profile without setting this.
+The dbt container needs a project to run. To develop and test models locally, [set up a dbt project]({{< relref "hosting/analytics/building-dbt-models#setup" >}}) and set the path to the project to the `DBT_LOCAL_PATH` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}) in `.env`. You must set this to a valid directory where you have your CHT Pipeline models. You can not use `--local` profile without setting this.
 
-When running, the  dbt container then will use the local models in the path specified in `DBT_LOCAL_PATH` with out needing to query a remote git repository.
+When running, the dbt container then will use the local models in the path specified in `DBT_LOCAL_PATH` with out needing to query a remote git repository.
 
 Run the Docker containers locally and wait for every container to be up and running:
 ```sh

--- a/content/en/hosting/analytics/setup-docker-compose.md
+++ b/content/en/hosting/analytics/setup-docker-compose.md
@@ -50,7 +50,7 @@ docker compose --profile local up -d
 
 You can verify this command worked by running `docker ps`. It should show four containers running including couch2pg, dbt, PostgreSQL, and pgAdmin.
 
-When developing DBT models, it is helpful to test changes locally before committing them to a remote repository.
+When developing dbt models, it is helpful to test changes locally before committing them to a remote repository.
 
 Set the path to the project to the `DBT_LOCAL_PATH` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}) in `.env`.
 
@@ -67,23 +67,18 @@ docker compose --profile production up -d
 
 You can verify this command worked by running `docker ps`. It should show three containers running: dbt, couch2pg and bastion.
 
-### Tuning DBT performance
+### Tuning dbt
 
-In production setups with large tables, it can be helpful to control how DBT runs.
+In production setups with large tables, it can be helpful to [tune how dbt runs]({{< relref "hosting/analytics/tuning-dbt" >}}).
 
-#### Threads
+To use threads or batching, set the corresponding environment variables in `.env`.
+```
+DBT_THREADS=3
+DBT_BATCH_SIZE=100000
+```
 
-the `DBT_THREADS` variable can be used to allow dbt to run independent models concurrently in the same process using threads.
-
-#### Batching
-
-For large tables, it may take a long time for all rows to be copied from the source table into the base models if the base models are very out of date or the first time CHT Sync is run. The `DBT_BATCH_SIZE` variable can be used to limit the number of records inserted in a single dbt run, which allows models to catch up to real-time gradually and progressively.
-
-#### DBT tags
-You can use [dbt tags](https://docs.getdbt.com/reference/resource-configs/tags) to run different sets of models independently. This can be useful if any custom models take a long time to update; by running some models independently from others, faster models can be allowed to complete before the slower models are finished.
-To do this, add dbt containers with different values set for the `DBT_SELECTOR` environment variable. This variable will be passed to each dbt container as a `--select` argument. If it is set, the dbt container will only run models matching the [select condition](https://docs.getdbt.com/reference/node-selection/syntax#how-does-selection-work). Although its possible to include any condition, using tags is the simplest way to separate models. Ensure that models match only one condition, and include a selector `package:cht_pipeline_base` so that base models are run.
-
-To do this, add an additional docker-compose file with different dbt containers and use profiles to control which services run.
+To use multiple dbt containers, add an additional docker-compose file with different dbt containers and use profiles to control which services run.
+Use the `DBT_SELECTOR` environment variable to change which models each container runs.
 
 ```yaml
 name: ${COMPOSE_PROJECT_NAME:-cht-sync}

--- a/content/en/hosting/analytics/setup-docker-compose.md
+++ b/content/en/hosting/analytics/setup-docker-compose.md
@@ -30,36 +30,121 @@ Configure the `COUCHDB_*` environment variables to connect to your CouchDB insta
 The first time you run the commands from any of the sections below it will need to download many Docker images and will take a while. You'll know it's done when you see `#8 DONE 0.0s` and you are returned to the command line. Be patient!
 {{% /alert %}}
 
-### Separate CouchDB instance 
+### Profiles
+
+Running CHT Sync uses docker compose profiles to organize different sets of services. 
+
+The following profiles are available:
+- `local` - for local model development
+- `production` - recommended setup for production
+- `test` - for automated tests
+
+#### Local
 
 This setup involves starting couch2pg, PostgreSQL, pgAdmin and dbt. It assumes you have a CouchDB instance running, and you updated the `.env` CouchDB variables accordingly.
 
 Run the Docker containers locally and wait for every container to be up and running:
 ```sh
-docker compose -f docker-compose.postgres.yml -f docker-compose.yml up -d
+docker compose --profile local up -d
 ```
 
-You can verify this command worked by running `docker ps`. It should show 4 containers running including couch2pg, dbt, PostgreSQL, and pgAdmin.
+You can verify this command worked by running `docker ps`. It should show four containers running including couch2pg, dbt, PostgreSQL, and pgAdmin.
 
-### Separate CouchDB and PostgreSQL instances
+When developing DBT models, it is helpful to test changes locally before commiting them to a remote repository.
 
-This local setup involves starting couch2pg and dbt. It assumes that CouchDB and PostgreSQL instances are run separately from the Docker Compose provided with CHT Sync, and the `.env` variables were updated to match those instances details.
+Set the path to the project to the `DBT_LOCAL_PATH` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}) in `.env`.
 
-Run the Docker containers locally and wait for every container to be up and running:
+The dbt container will run the models in the path specified in `DBT_LOCAL_PATH`.
+
+#### Production
+
+This setup involves starting couch2pg and one dbt container. It assumes you have an external CouchDB instance and Postgres DB. The credentials and settings for these databases are configured in [.env]({{< relref "hosting/analytics/environment-variables" >}}).
+
+Run the Docker containers with profile `production` and wait for every container to be up and running:
 ```sh
-docker compose -f docker-compose.yml up -d
+docker compose --profile production up -d
 ```
 
-You can verify this command worked by running `docker ps`. It should show 2 containers running: couch2pg and dbt.
+You can verify this command worked by running `docker ps`. It should show three containers running; dbt, couch2pg and bastion.
+
+### Controlling DBT performance
+
+In production setups with large tables, it can be helpful to control how DBT runs.
+
+#### Threads
+
+the `DBT_THREADS` variable can be used to allow dbt to run independent models concurrently in same process using threads.
+
+#### Batching
+
+For large tables, it may take a long time for all rows to be copied from the source table into the base models if the base models are very out of date or the first time CHT Sync is run. The `DBT_BATCH_SIZE` variable can be used to limit the number of records inserted in a single dbt run, which allows models to catch up to real time gradually and progressively.
+
+#### DBT tags
+You can use [dbt tags](https://docs.getdbt.com/reference/resource-configs/tags) to run different sets of models independently. This can be useful if any custom models take a long time to update; by running some models independently from others, faster models can be allowed to complete before the slower models are finished.
+To do this, add dbt containers with different values set for the `DBT_SELECTOR` environment variable. This variable will be passed to each dbt container as a `--select` argument. If it is set, the dbt conatiner will only run models matching the [select condition](https://docs.getdbt.com/reference/node-selection/syntax#how-does-selection-work). Although its possible to include any condition, using tags is the simplest way to separate models. Ensure that models match only one condition, and include a selector `package:cht_pipeline_base` so that base models are run.
+
+To do this, add an additional docker-compose file with different dbt containers and use profiles to control which services run.
+
+```yaml
+name: ${COMPOSE_PROJECT_NAME:-cht-sync}
+
+x-dbt-base: &dbt-common
+  build: ./dbt/
+  working_dir: /dbt/
+  environment: &dbt-env
+    POSTGRES_HOST: ${POSTGRES_HOST}
+    POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+    POSTGRES_USER: ${POSTGRES_USER}
+    POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    POSTGRES_DB: ${POSTGRES_DB}
+    POSTGRES_TABLE: ${POSTGRES_TABLE}
+    POSTGRES_SCHEMA: ${POSTGRES_SCHEMA}
+    ROOT_POSTGRES_SCHEMA: ${POSTGRES_SCHEMA}
+    DATAEMON_INTERVAL: ${DATAEMON_INTERVAL}
+    DBT_THREAD_COUNT: ${DBT_THREAD_COUNT}
+    DBT_BATCH_SIZE: ${DBT_BATCH_SIZE}
+
+services:
+  dbt-tag-one:
+    <<: *dbt-common
+    profiles:
+      - tags
+    environment:
+      <<: *dbt-env
+      DBT_SELECTOR: package:cht_pipeline_base
+      CHT_PIPELINE_BRANCH_URL: ${CHT_PIPELINE_BRANCH_URL}
+
+  dbt-tag-one:
+    <<: *dbt-common
+    profiles:
+      - tags
+    environment:
+      <<: *dbt-env
+      DBT_SELECTOR: tag:tag-one
+      CHT_PIPELINE_BRANCH_URL: ${CHT_PIPELINE_BRANCH_URL}
+
+  dbt-tag-two:
+    <<: *dbt-common
+    profiles:
+      - tags
+    environment:
+      <<: *dbt-env
+      DBT_SELECTOR: tag:tag-two
+      CHT_PIPELINE_BRANCH_URL: ${CHT_PIPELINE_BRANCH_URL}
+```
+
+```sh
+docker compose --profile tags --profile production -f docker-compose.yml -f docker-compose.dbt-tags.yml up -d
+```
 
 ### Cleanup
 
 When you are done using the services, you can clean everything by running `down`.
 
-For example, in the scenario of [separate couchdb instance]({{< relref "#separate-couchdb-instance" >}}), the command should look like:
+For example, using the local profile, the command should look like:
 
 ```sh
-docker compose -f docker-compose.postgres.yml -f docker-compose.yml down
+docker compose -f docker-compose.yml down
 ```
 
 To remove all the data volumes, add `-v` at the end of this command.

--- a/content/en/hosting/analytics/setup-docker-compose.md
+++ b/content/en/hosting/analytics/setup-docker-compose.md
@@ -154,3 +154,25 @@ docker compose -f docker-compose.yml down
 ```
 
 To remove all the data volumes, add `-v` at the end of this command.
+
+### Upgrading
+
+To upgrade to a newer version of CHT Sync with docker, stop all containers, and pull the newer version.
+If there are any database changes that require a migration script, the major version will be changed and the changes detailed below.
+After running any migrations scripts, restart containers with the new docker-compose.yml
+
+```sh
+docker compose --profile production up -d
+```
+
+#### Upgrading V1 to V2
+
+V2 added the `source` column to the `couchdb` table, and several other columns to the metadata table.
+To add these columns log in to the database and run this sql. 
+
+```sql
+  ALTER TABLE _dataemon ADD COLUMN IF NOT EXISTS manifest jsonb;
+  ALTER TABLE _dataemon ADD COLUMN IF NOT EXISTS dbt_selector text;
+  ALTER TABLE couchdb ADD COLUMN IF NOT EXISTS source varchar;
+  CREATE INDEX IF NOT EXISTS source ON couchdb(source);
+```

--- a/content/en/hosting/analytics/setup-docker-compose.md
+++ b/content/en/hosting/analytics/setup-docker-compose.md
@@ -176,3 +176,7 @@ To add these columns log in to the database and run this sql.
   ALTER TABLE couchdb ADD COLUMN IF NOT EXISTS source varchar;
   CREATE INDEX IF NOT EXISTS source ON couchdb(source);
 ```
+
+In V2, the commands for running CHT sync have changed; a profile is required as described above.
+When testinging locally and using the `local` profile, the environment variable `DBT_LOCAL_PATH` must be set.
+V2 adds new features for [tuning dbt]({{< relref "hosting/analytics/tuning-dbt" >}}); to use batching, threads, or separate dbt processes, set the corresponding [environment_variables]({{< relref "hosting/analytics/environment-variables" >}}) in `.env` as described above.

--- a/content/en/hosting/analytics/setup-docker-compose.md
+++ b/content/en/hosting/analytics/setup-docker-compose.md
@@ -19,7 +19,7 @@ This guide will walk you through setting up a deployment of CHT Sync with the CH
 - [Current version](https://docs.docker.com/engine/install/) of `docker` or current version of [Docker Desktop](https://www.docker.com/products/docker-desktop/) both of which include `docker compose`. Note that the older `docker-compose` is [no longer supported](https://www.docker.com/blog/announcing-compose-v2-general-availability/).
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [cht-sync](https://github.com/medic/cht-sync) GitHub repository (can be cloned via `git clone https://github.com/medic/cht-sync`).
-- [A dbt project](https://docs.getdbt.com/docs/build/projects).
+- [A dbt project]({{< relref "hosting/analytics/building-dbt-models" >}}).
 
 ## Setup
 

--- a/content/en/hosting/analytics/setup-docker-compose.md
+++ b/content/en/hosting/analytics/setup-docker-compose.md
@@ -50,7 +50,7 @@ docker compose --profile local up -d
 
 You can verify this command worked by running `docker ps`. It should show four containers running including couch2pg, dbt, PostgreSQL, and pgAdmin.
 
-When developing DBT models, it is helpful to test changes locally before commiting them to a remote repository.
+When developing DBT models, it is helpful to test changes locally before committing them to a remote repository.
 
 Set the path to the project to the `DBT_LOCAL_PATH` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}) in `.env`.
 
@@ -73,15 +73,15 @@ In production setups with large tables, it can be helpful to control how DBT run
 
 #### Threads
 
-the `DBT_THREADS` variable can be used to allow dbt to run independent models concurrently in same process using threads.
+the `DBT_THREADS` variable can be used to allow dbt to run independent models concurrently in the same process using threads.
 
 #### Batching
 
-For large tables, it may take a long time for all rows to be copied from the source table into the base models if the base models are very out of date or the first time CHT Sync is run. The `DBT_BATCH_SIZE` variable can be used to limit the number of records inserted in a single dbt run, which allows models to catch up to real time gradually and progressively.
+For large tables, it may take a long time for all rows to be copied from the source table into the base models if the base models are very out of date or the first time CHT Sync is run. The `DBT_BATCH_SIZE` variable can be used to limit the number of records inserted in a single dbt run, which allows models to catch up to real-time gradually and progressively.
 
 #### DBT tags
 You can use [dbt tags](https://docs.getdbt.com/reference/resource-configs/tags) to run different sets of models independently. This can be useful if any custom models take a long time to update; by running some models independently from others, faster models can be allowed to complete before the slower models are finished.
-To do this, add dbt containers with different values set for the `DBT_SELECTOR` environment variable. This variable will be passed to each dbt container as a `--select` argument. If it is set, the dbt conatiner will only run models matching the [select condition](https://docs.getdbt.com/reference/node-selection/syntax#how-does-selection-work). Although its possible to include any condition, using tags is the simplest way to separate models. Ensure that models match only one condition, and include a selector `package:cht_pipeline_base` so that base models are run.
+To do this, add dbt containers with different values set for the `DBT_SELECTOR` environment variable. This variable will be passed to each dbt container as a `--select` argument. If it is set, the dbt container will only run models matching the [select condition](https://docs.getdbt.com/reference/node-selection/syntax#how-does-selection-work). Although its possible to include any condition, using tags is the simplest way to separate models. Ensure that models match only one condition, and include a selector `package:cht_pipeline_base` so that base models are run.
 
 To do this, add an additional docker-compose file with different dbt containers and use profiles to control which services run.
 

--- a/content/en/hosting/analytics/setup-docker-compose.md
+++ b/content/en/hosting/analytics/setup-docker-compose.md
@@ -65,9 +65,9 @@ Run the Docker containers with profile `production` and wait for every container
 docker compose --profile production up -d
 ```
 
-You can verify this command worked by running `docker ps`. It should show three containers running; dbt, couch2pg and bastion.
+You can verify this command worked by running `docker ps`. It should show three containers running: dbt, couch2pg and bastion.
 
-### Controlling DBT performance
+### Tuning DBT performance
 
 In production setups with large tables, it can be helpful to control how DBT runs.
 

--- a/content/en/hosting/analytics/setup-docker-compose.md
+++ b/content/en/hosting/analytics/setup-docker-compose.md
@@ -41,18 +41,28 @@ The following profiles are available:
 
 #### Local
 
-This setup involves starting couch2pg, PostgreSQL, pgAdmin and dbt. It assumes you have a CouchDB instance running, and you updated the `.env` CouchDB variables accordingly.
+This setup involves starting couch2pg, PostgreSQL, pgAdmin and dbt. It assumes you have a CouchDB instance running, and you updated the `.env` CouchDB variables accordingly. 
+
+When developing DBT models, it is helpful to test changes locally before committing them to a remote repository. To do this, set the path to the project to the `DBT_LOCAL_PATH` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}) in `.env`. You must set this to a valid directory where you have your CHT Pipeline models. You can not use `--local` profile without setting this.
+
+When running, the  dbt container then will use the local models in the path specified in `DBT_LOCAL_PATH` with out needing to query a remote git repository.
 
 Run the Docker containers locally and wait for every container to be up and running:
 ```sh
 docker compose --profile local up -d
 ```
 
-You can verify this command worked by running `docker ps`. It should show four containers running including couch2pg, dbt, PostgreSQL, and pgAdmin.
+You can verify this command worked by running `docker compose --profile local ps --format "{{.Names}}\t{{.Status}}"`. It should show four containers running including couch2pg, dbt, PostgreSQL, and pgAdmin:
+
+```
+cht-sync-couch2pg-1     Up About a minute
+cht-sync-dbt-local-1    Up About a minute
+cht-sync-pgadmin-1      Up About a minute
+cht-sync-postgres-1     Up About a minute
+```
 
 When developing dbt models, it is helpful to test changes locally before committing them to a remote repository.
 
-Set the path to the project to the `DBT_LOCAL_PATH` [environment variable]({{< relref "hosting/analytics/environment-variables" >}}) in `.env`.
 
 The dbt container will run the models in the path specified in `DBT_LOCAL_PATH`.
 

--- a/content/en/hosting/analytics/setup-kubernetes.md
+++ b/content/en/hosting/analytics/setup-kubernetes.md
@@ -167,3 +167,5 @@ To add these columns log in to the database and run this sql.
   ALTER TABLE couchdb ADD COLUMN IF NOT EXISTS source varchar;
   CREATE INDEX IF NOT EXISTS source ON couchdb(source);
 ```
+
+V2 adds new features for [tuning dbt]({{< relref "hosting/analytics/tuning-dbt" >}}); to use batching, threads, or separate dbt processes, set the corresponding [environment_variables]({{< relref "hosting/analytics/environment-variables" >}}) in `values.yml` as described above.

--- a/content/en/hosting/analytics/setup-kubernetes.md
+++ b/content/en/hosting/analytics/setup-kubernetes.md
@@ -103,7 +103,7 @@ metrics_exporter:
 ```
 ## Deploy
 
-Run the command below to deploy the cht-sync helm chart. The chart is at `deploy/cht_sync`; if `values.yaml` is in a different directory, specify the path.
+Run the command below to deploy the CHT Sync helm chart. The chart is at `deploy/cht_sync`; if `values.yaml` is in a different directory, specify the path.
 
 ```shell
 cd deploy/cht_sync
@@ -130,7 +130,7 @@ In production setups with large tables, it can be helpful to control how DBT run
 
 #### Threads
 
-the `dbt_threads` variable can be used to allow dbt to run independent models concurrently in same process using threads.
+the `dbt_threads` variable can be used to allow dbt to run independent models concurrently in the same process using threads.
 
 ```yaml
 dbt_thread_count: 3
@@ -138,7 +138,7 @@ dbt_thread_count: 3
 
 #### Batching
 
-For large tables, it may take a long time for all rows to be copied from the source table into the base models if the base models are very out of date or the first time cht-sync is run. The `dbt_batch_size` value can be used to limit the number of records inserted in a single dbt run, which allows models to catch up to real time gradually and progressively.
+For large tables, it may take a long time for all rows to be copied from the source table into the base models if the base models are very out of date or the first time CHT Sync is run. The `dbt_batch_size` value can be used to limit the number of records inserted in a single dbt run, which allows models to catch up to real time gradually and progressively.
 
 ```yaml
 dbt_batch_size: 100000

--- a/content/en/hosting/analytics/setup-kubernetes.md
+++ b/content/en/hosting/analytics/setup-kubernetes.md
@@ -145,3 +145,25 @@ dbt_selectors:
   - "tag:tag-two"
 ```
 
+### Upgrading
+
+To upgrade to a newer version of CHT Sync with kubernetes, run helm upgrade.
+If there are any database changes that require a migration script, the major version will be changed and the changes detailed below.
+After running any migrations scripts, restart containers with the new docker-compose.yml
+
+```shell
+cd deploy/cht_sync
+helm upgrade cht-sync . --values values.yaml
+```
+
+#### Upgrading V1 to V2
+
+V2 added the `source` column to the `couchdb` table, and several other columns to the metadata table.
+To add these columns log in to the database and run this sql. 
+
+```sql
+  ALTER TABLE _dataemon ADD COLUMN IF NOT EXISTS manifest jsonb;
+  ALTER TABLE _dataemon ADD COLUMN IF NOT EXISTS dbt_selector text;
+  ALTER TABLE couchdb ADD COLUMN IF NOT EXISTS source varchar;
+  CREATE INDEX IF NOT EXISTS source ON couchdb(source);
+```

--- a/content/en/hosting/analytics/setup-kubernetes.md
+++ b/content/en/hosting/analytics/setup-kubernetes.md
@@ -124,7 +124,7 @@ Run the following command to get the logs of a pod.
 kubectl logs -f cht-sync-<pod-id>
 ```
 
-### Controlling DBT Performance
+### Tuning DBT Performance
 
 In production setups with large tables, it can be helpful to control how DBT runs.
 

--- a/content/en/hosting/analytics/setup-kubernetes.md
+++ b/content/en/hosting/analytics/setup-kubernetes.md
@@ -124,29 +124,19 @@ Run the following command to get the logs of a pod.
 kubectl logs -f cht-sync-<pod-id>
 ```
 
-### Tuning DBT Performance
+### Tuning dbt
 
-In production setups with large tables, it can be helpful to control how DBT runs.
-
-#### Threads
-
-the `dbt_threads` variable can be used to allow dbt to run independent models concurrently in the same process using threads.
+In production setups with large tables, it can be helpful to [tune how dbt runs]({{< relref "hosting/analytics/tuning-dbt" >}}).
+To use threads or batching, set the corresponding values in the `values.yaml` file.
 
 ```yaml
 dbt_thread_count: 3
-```
-
-#### Batching
-
-For large tables, it may take a long time for all rows to be copied from the source table into the base models if the base models are very out of date or the first time CHT Sync is run. The `dbt_batch_size` value can be used to limit the number of records inserted in a single dbt run, which allows models to catch up to real time gradually and progressively.
-
-```yaml
 dbt_batch_size: 100000
 ```
 
-#### Separate DBT pods
-You can use [dbt tags](https://docs.getdbt.com/reference/resource-configs/tags) to run different sets of models independently. This can be useful if any custom models take a long time to update; by running some models independently from others, faster models can be allowed to complete before the slower models are finished. 
-To do this, specify the tags in a list called `dbt_selectors`. These will be passed to dbt as `--select` arguments. If this value is specified, only models matching one [select condition](https://docs.getdbt.com/reference/node-selection/syntax#how-does-selection-work) will be run. Although its possible to include any condition, using tags is the simplest way to separate models. Ensure that models match only one condition, and include a selector `package:cht_pipeline_base` so that base models are run.
+To use multiple dbt containers, specify the different selectors in a list called `dbt_selectors`.
+
+This will create one pod running dbt for each entry, where each entry is passed to one dbt pod as a `--select` argument.
 
 ```yaml
 dbt_selectors:

--- a/content/en/hosting/analytics/tuning-dbt.md
+++ b/content/en/hosting/analytics/tuning-dbt.md
@@ -1,0 +1,57 @@
+---
+title: "Tuning dbt runs for performance"
+weight: 6
+linkTitle: "dbt Tuning"
+description: >
+  Tuning DBT variables for performance
+relatedContent: >
+  core/overview/cht-sync
+  hosting/analytics/environment-variables
+  hosting/analytics/setup-docker-compose
+  hosting/analytics/setup-kubernetes
+---
+
+In production setups with large tables, it can be helpful to control how DBT runs.
+
+## Threads
+
+The `DBT_THREADS` variable can be used to allow dbt to run independent models concurrently in the same process using threads.
+
+This can allow models to update more quickly by reducing the total duration of a dbt run.
+
+More threads means more database processes running concurrently which can create performance issues; this value is per process, so if running separate processes, the total number of concurrent processes in the db will be `DBT_THREADS x the number of processes`.
+For a single process, models can only be run concurrently if they are independent; if model A depends on model B, model A will never be run before model A finishes.
+
+A sensible default is `DBT_THREADS=3`.
+
+## Batching
+
+For large tables, it may take a long time for all rows to be copied from the source table into the base models the first the CHT Sync is run, or if the base models are very out of date. The `DBT_BATCH_SIZE` variable can be used to limit the number of records inserted in a single dbt run, which allows models to catch up to real-time gradually and progressively.
+Batch size can be tuned to reduce the duration of a single dbt run, but setting it too small will not have a significant effect, and models will not be able to catch up to real-time if the batch size is smaller than the number of records added to the `couchdb` table during a single dbt run.
+
+A sensible default is `DBT_BATCH_SIZE=100000`.
+
+## Multiple dbt containers
+Instead of a single dbt container that runs all models, CHT Sync allows multiple dbt containers that each run a different set of models independently.
+This can be useful if any custom models take a long time to update; by running some models independently from others, faster models can complete before the slower models are finished.
+
+Each dbt container is passed an environment variable `DBT_SELECTOR` that is used as a `--select` [argument](https://docs.getdbt.com/reference/node-selection/methods) to the dbt command.
+
+One dbt container should be set up to run the base models. This can be done by using the selector `package:cht_pipeline_base` or, to separate telemetry models from base models, using `tag:base` and `tag:users`.
+
+To run custom models in separate containers, either use a package select with your dbt package name (`package:[YOUR_PACKAGE_NAME]`), or for more fine-grained control, add [tags]({{< relref "hosting/analytics/tuning-dbt#dbt-tags" >}}) to your models and use tag selectors (`tag:[YOUR_TAG]`).
+Although it is possible to use any condition, using tags is the simplest way to separate models.
+
+How to configure the different dbt containers to use these selectors depends on whether CHT Sync is running in [docker-compose]({{< relref "hosting/analytics/setup-docker-compose#tuning-dbt" >}}) or [kubernetes]({{< relref "hosting/analytics/setup-kubernetes#tuning-dbt" >}}).
+
+In Kubernetes, add the selectors to the `values.yaml` file as a list called `dbt_selectors`
+```yaml
+dbt_selectors:
+  - "package:cht_pipeline_base"
+  - "tag:tag-one"
+  - "tag:tag-two"
+```
+
+This will create one pod per selector.
+
+With docker compose, create a new docker compose file and include one dbt container per selector.

--- a/content/en/hosting/analytics/tuning-dbt.md
+++ b/content/en/hosting/analytics/tuning-dbt.md
@@ -20,24 +20,24 @@ The `DBT_THREADS` variable can be used to allow dbt to run independent models co
 This can allow models to update more quickly by reducing the total duration of a dbt run.
 
 More threads means more database processes running concurrently which can create performance issues; this value is per process, so if running separate processes, the total number of concurrent processes in the db will be `DBT_THREADS x the number of processes`.
-For a single process, models can only be run concurrently if they are independent; if model A depends on model B, model A will never be run before model A finishes.
+For a single process, models can only be run concurrently if they are independent; if model A depends on model B, model A will never be run before model B finishes.
 
 A sensible default is `DBT_THREADS=3`.
 
 ## Batching
 
-For large tables, it may take a long time for all rows to be copied from the source table into the base models the first the CHT Sync is run, or if the base models are very out of date. The `DBT_BATCH_SIZE` variable can be used to limit the number of records inserted in a single dbt run, which allows models to catch up to real-time gradually and progressively.
+For large tables, it may take a long time for all rows to be copied from the source table into the base models the first time CHT Sync is run, or if the base models are very out of date. The `DBT_BATCH_SIZE` variable can be used to limit the number of records inserted in a single dbt run, which allows models to catch up to real-time gradually and progressively.
 Batch size can be tuned to reduce the duration of a single dbt run, but setting it too small will not have a significant effect, and models will not be able to catch up to real-time if the batch size is smaller than the number of records added to the `couchdb` table during a single dbt run.
 
 A sensible default is `DBT_BATCH_SIZE=100000`.
 
 ## Multiple dbt containers
-Instead of a single dbt container that runs all models, CHT Sync allows multiple dbt containers that each run a different set of models independently.
+Instead of a single dbt container that runs all models, CHT Sync supports having multiple dbt containers that each run a different set of models independently.
 This can be useful if any custom models take a long time to update; by running some models independently from others, faster models can complete before the slower models are finished.
 
 Each dbt container is passed an environment variable `DBT_SELECTOR` that is used as a `--select` [argument](https://docs.getdbt.com/reference/node-selection/methods) to the dbt command.
 
-One dbt container should be set up to run the base models. This can be done by using the selector `package:cht_pipeline_base` or, to separate telemetry models from base models, using `tag:base` and `tag:users`.
+One dbt container should be set up to run the base models. This can be done by using the selector `package:cht_pipeline_base` or, to separate telemetry models from base models, use `tag:base` and `tag:users`.
 
 To run custom models in separate containers, either use a package select with your dbt package name (`package:[YOUR_PACKAGE_NAME]`), or for more fine-grained control, add [tags]({{< relref "hosting/analytics/tuning-dbt#dbt-tags" >}}) to your models and use tag selectors (`tag:[YOUR_TAG]`).
 Although it is possible to use any condition, using tags is the simplest way to separate models.


### PR DESCRIPTION
Docs for upcoming CHT Sync v2 release.  This PR:
* adds setup info for V2
* adds setup info for local DBT models (instead of remote files checked into `git`)
* covers new compose deployments using profiles

When following setup steps in this docs PR, be sure your CHT Sync repo is on the `v2` [branch](https://github.com/medic/cht-sync/tree/v2) per [this PR](https://github.com/medic/cht-sync/pull/202). That will make sure the ` --profile` logic is added to the compose files and the `.env` created from the example on has the new `DBT_LOCAL_PATH` value.