### PR TITLE
fix: fix hugo url

### DIFF
--- a/content/en/contribute/docs/style-guide.md
+++ b/content/en/contribute/docs/style-guide.md
@@ -149,7 +149,7 @@ Connecting readers to related content in different pages is an important aspect 
    ``` 
 
 ### Avoid broken links
-To avoid broken links always use `ref` or `relref` shortcodes for internal references with the full path for the page. Check out the [Hugo documentation for cross-references](https://gohugo.io/content-management/cross-references/) for more details.
+To avoid broken links always use `ref` or `relref` shortcodes for internal references with the full path for the page. Check out the [Hugo documentation for cross-references](https://gohugo.io/content-management/shortcodes/#article) for more details.
 
 For example,  `[Icon Library]({{</* relref "design/interface/icons" */>}})` yields "[Icon Library]({{% relref "design/interface/icons" %}})". Using the full path will avoid ambiguous references if a new page of the same is created. 
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Fix `404` URL per link checker.

```
4m 18s
Run chmod +x ./.github/scripts/*muffet*
http://localhost:[1](https://github.com/medic/cht-docs/commit/39ab3ef13feb1598abffb3e58c32447e09cdc49d/checks#step:7:1)313/contribute/docs/style-guide/
	404	https://gohugo.io/content-management/cross-references/
Error: Process completed with exit code 1.
```

Please note that ref and relref became redundant and this documentation might need a more thorough review:

>When working with the Markdown [content format](https://gohugo.io/content-management/formats/), this shortcode has become largely redundant. Its functionality is now primarily handled by [link render hooks](https://gohugo.io/render-hooks/images/#default), specifically the embedded one provided by Hugo. This hook effectively addresses all the use cases previously covered by this shortcode.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

