### PR TITLE
feat(#1816): clarify how to disable purging in app_settings

### DIFF
--- a/content/en/building/guides/performance/purging.md
+++ b/content/en/building/guides/performance/purging.md
@@ -98,7 +98,7 @@ module.exports = {
 };
 ```
 
-To disable purging, you need to explicitly configure the purge key with an empty object value, as in this example:
+To disable purging, you need to explicitly configure the purge key with an empty object value in the `app_settings.json` file, as in this example:
 
 ```json
 "purge": {}

--- a/content/en/building/guides/performance/purging.md
+++ b/content/en/building/guides/performance/purging.md
@@ -22,12 +22,6 @@ As users continually generate new reports their performance may naturally degrad
 
 Purging is disabled by default, and is enabled if a purge function is specified in `app_settings.json`, along with a run schedule.
 
-**Important:** Simply removing the `purge` key from `app_settings.json` will not disable purging. To properly disable purging, you must explicitly set the purge key to an empty object, as shown below:
-
-```json
-"purge": {}
-```
-
 The following example would purge all reports that were created more than a year ago:
 
 ```json
@@ -102,6 +96,12 @@ module.exports = {
     return [...reportsToPurge, ...messagesToPurge];
   }
 };
+```
+
+To disable purging, you need to explicitly configure the purge key with an empty object value, as in this example:
+
+```json
+"purge": {}
 ```
 
 ### Purge configuration

--- a/content/en/building/guides/performance/purging.md
+++ b/content/en/building/guides/performance/purging.md
@@ -22,6 +22,12 @@ As users continually generate new reports their performance may naturally degrad
 
 Purging is disabled by default, and is enabled if a purge function is specified in `app_settings.json`, along with a run schedule.
 
+**Important:** Simply removing the `purge` key from `app_settings.json` will not disable purging. To properly disable purging, you must explicitly set the purge key to an empty object, as shown below:
+
+```json
+"purge": {}
+```
+
 The following example would purge all reports that were created more than a year ago:
 
 ```json


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

This PR updates the `purging.md` documentation to clarify that removing the `purge` key from `app_settings.json` does **not** disable purging. Instead, the purge key must be set to an empty object (`{}`).
Closes https://github.com/medic/cht-docs/issues/1816  
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

