### PR TITLE
chore(#1118): android 12+ cannot use magic links

### DIFF
--- a/content/en/building/concepts/access.md
+++ b/content/en/building/concepts/access.md
@@ -72,7 +72,6 @@ Subsequent logins won’t require a password change – if the app closes before
 
 
 ## Magic Links for Logging In (Token Login)
-
  ❗ **Note:** Magic Links do not currently work on Android 12 and above.
 
 {{< figure src="enable.token.login.gif" alt="Animated image showing the 'Enable login via SMS link' check box being clicked and 'password' and 'confirm password' fields being hidden" class="right col-6 col-lg-9" >}}

--- a/content/en/building/concepts/access.md
+++ b/content/en/building/concepts/access.md
@@ -73,6 +73,8 @@ Subsequent logins won’t require a password change – if the app closes before
 
 ## Magic Links for Logging In (Token Login)
 
+> ❗ **Note:** Magic Links do not currently work on Android 12 and above.
+
 {{< figure src="enable.token.login.gif" alt="Animated image showing the 'Enable login via SMS link' check box being clicked and 'password' and 'confirm password' fields being hidden" class="right col-6 col-lg-9" >}}
 
 When creating users, the admin has the option to enable a user to login in by simply clicking a link sent via SMS. When the token login link is clicked and the app is not installed on the user's phone, it will open in their default browser. If no gateway is set up on the CHT server, the message may be sent via another messaging app. The link is only valid for 24 hours and can only be used once to log in. This ensures the link is used only by the intended recipient. By clicking the magic link, the user is logged into their project's instance directly, bypassing the need to manually enter a username and password.  

--- a/content/en/building/concepts/access.md
+++ b/content/en/building/concepts/access.md
@@ -73,7 +73,7 @@ Subsequent logins won’t require a password change – if the app closes before
 
 ## Magic Links for Logging In (Token Login)
 
-> ❗ **Note:** Magic Links do not currently work on Android 12 and above.
+ ❗ **Note:** Magic Links do not currently work on Android 12 and above.
 
 {{< figure src="enable.token.login.gif" alt="Animated image showing the 'Enable login via SMS link' check box being clicked and 'password' and 'confirm password' fields being hidden" class="right col-6 col-lg-9" >}}
 


### PR DESCRIPTION
Closes #1118
This PR solves the issue as now it is specified that user having android 12+ can't use the magic links .


