### PR TITLE
fix redirects after hosting content reshuffle

### DIFF
--- a/content/en/hosting/4.x/docker/_index.md
+++ b/content/en/hosting/4.x/docker/_index.md
@@ -3,11 +3,6 @@ title: "Docker Production Hosting CHT 4.x"
 linkTitle: "Production Docker"
 weight: 15
 aliases:
-   - /apps/guides/hosting/4.x/self-hosting/single-node/
-   - /hosting/4.x/self-hosting/single-node/
-   - ../self-hosting-single-node
-   - /hosting/4.x/docker/single-node/
-   - /hosting/4.x/production/docker/
 ---
 
 {{< hextra/hero-subtitle >}}

--- a/content/en/hosting/4.x/docker/_index.md
+++ b/content/en/hosting/4.x/docker/_index.md
@@ -7,7 +7,7 @@ aliases:
    - /hosting/4.x/self-hosting/single-node/
    - ../self-hosting-single-node
    - /hosting/4.x/docker/single-node/
-   - /hosting/4.x/docker/
+   - /hosting/4.x/production/docker/
 ---
 
 {{< hextra/hero-subtitle >}}

--- a/content/en/hosting/4.x/docker/adding-tls-certificates.md
+++ b/content/en/hosting/4.x/docker/adding-tls-certificates.md
@@ -5,6 +5,7 @@ weight: 2
 aliases:
   - /apps/guides/hosting/4.x/adding-tls-certificates
   - /hosting/4.x/adding-tls-certificates
+  - /hosting/4.x/production/docker/adding-tls-certificates/
 ---
 
 {{< hextra/hero-subtitle >}}

--- a/content/en/hosting/4.x/docker/backups.md
+++ b/content/en/hosting/4.x/docker/backups.md
@@ -5,6 +5,7 @@ weight: 4
 aliases:
   - /apps/guides/hosting/4.x/backups
   - /hosting/4.x/backups
+  - /hosting/4.x/production/docker/backups/
 ---
 
 {{< hextra/hero-subtitle >}}

--- a/content/en/hosting/4.x/docker/installation.md
+++ b/content/en/hosting/4.x/docker/installation.md
@@ -5,6 +5,11 @@ weight: 1
 aliases:
   - /apps/guides/hosting/4.x/docker/
   - /hosting/4.x/docker/prerequisites/
+  - /apps/guides/hosting/4.x/self-hosting/single-node/
+  - /hosting/4.x/self-hosting/single-node/
+  - ../self-hosting-single-node
+  - /hosting/4.x/docker/single-node/
+  - /hosting/4.x/production/docker/
 ---
 
 {{< hextra/hero-subtitle >}}

--- a/content/en/hosting/4.x/docker/logs.md
+++ b/content/en/hosting/4.x/docker/logs.md
@@ -5,6 +5,7 @@ weight: 3
 aliases:
   - /apps/guides/hosting/4.x/logs
   - /hosting/4.x/logs
+  - /hosting/4.x/production/docker/logs/
 ---
 
 {{< hextra/hero-subtitle >}}

--- a/content/en/hosting/4.x/kubernetes/gcp-multinode.md
+++ b/content/en/hosting/4.x/kubernetes/gcp-multinode.md
@@ -4,6 +4,7 @@ linkTitle: "GCP + GKS Multi Node"
 weight: 10
 aliases:
    - /hosting/4.x/docker/google-cloud/
+   - /hosting/4.x/production/kubernetes/gcp-multinode/
 ---
 
 {{< hextra/hero-subtitle >}}

--- a/content/en/hosting/4.x/kubernetes/self-hosting-k3s-multinode.md
+++ b/content/en/hosting/4.x/kubernetes/self-hosting-k3s-multinode.md
@@ -6,6 +6,7 @@ aliases:
   - /apps/guides/hosting/4.x/self-hosting/self-hosting-k3s-multinode
   - /hosting/4.x/self-hosting/self-hosting-k3s-multinode
   - ../self-hosting-k3s-multinode
+  - /hosting/4.x/production/kubernetes/self-hosting-k3s-multinode/
 ---
 
 {{< hextra/hero-subtitle >}}


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description
After moving hosting directory structure in [a recent PR](https://github.com/medic/cht-docs/pull/1873), I see now redirects were missing or broken.  This PR fixes all those redirects

eg `/hosting/4.x/production/docker/` -> `/hosting/4.x/docker/installation/` which didn't work before

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

