### PR TITLE
feat: note version of cht-android required for SSO

### DIFF
--- a/content/en/building/reference/api.md
+++ b/content/en/building/reference/api.md
@@ -1992,6 +1992,10 @@ If `app_settings.app_url` is not defined, the generated token-login URL will use
 
 #### Login by OIDC
 
+{{< callout >}}
+Introduced in 4.20.0. This feature is only compatible with cht-android version `v1.5.2` or greater.
+{{< /callout >}}
+
 When [SSO Login]({{< ref "hosting/sso" >}}) is enabled (by configuring the [`oidc_provider` settings]({{< ref "building/reference/app-settings/oidc_provider" >}})), a CHT user must be provisioned for each SSO user prior to them logging in.  The CHT user's `oidc_username` property must be set to the value of the user's `email` claim from the OIDC Provider.
 
 Two CHT users cannot share the same `oidc_username` value. Setting the `oidc_username` property for a user will cause the user's password (in the CHT) to be set to a random value, preventing them from logging in with other authentication methods. Instead, the user must log in using the "Login with SSO" button.

--- a/content/en/building/reference/app-settings/oidc_provider.md
+++ b/content/en/building/reference/app-settings/oidc_provider.md
@@ -12,6 +12,10 @@ relatedContent: >
   building/reference/app-settings/token_login
 ---
 
+{{< callout >}}
+Introduced in 4.20.0. This feature is only compatible with cht-android version `v1.5.2` or greater.
+{{< /callout >}}
+
 To support [authenticating users with Single Sign-On]({{< ref "hosting/sso" >}}) (SSO) credentials (instead of CHT-specific usernames/passwords), the CHT can integrate with an external authorization server that supports the [OpenID Connect](https://openid.net/) (OIDC) protocol. Configure the OIDC Provider connection settings under the `oidc_provider` key:
 
 ## `app_settings.json .oidc_provider`

--- a/content/en/hosting/SSO/_index.md
+++ b/content/en/hosting/SSO/_index.md
@@ -10,7 +10,7 @@ relatedContent: >
 ---
 
 {{< callout >}}
-Introduced in 4.20.0
+Introduced in 4.20.0. This feature is only compatible with cht-android version `v1.5.2` or greater.
 {{< /callout >}}
 
 ## Overview

--- a/content/en/hosting/SSO/entra.md
+++ b/content/en/hosting/SSO/entra.md
@@ -6,7 +6,7 @@ weight: 200
 
 
 {{< callout >}}
-Introduced in 4.20.0
+Introduced in 4.20.0. This feature is only compatible with cht-android version `v1.5.2` or greater.
 {{< /callout >}}
 
 ## Introduction

--- a/content/en/hosting/SSO/keycloak.md
+++ b/content/en/hosting/SSO/keycloak.md
@@ -6,7 +6,7 @@ weight: 100
 
 
 {{< callout >}}
-Introduced in 4.20.0
+Introduced in 4.20.0. This feature is only compatible with cht-android version `v1.5.2` or greater.
 {{< /callout >}}
 
 ## Introduction

--- a/content/en/hosting/SSO/technical.md
+++ b/content/en/hosting/SSO/technical.md
@@ -5,7 +5,7 @@ weight: 400
 ---
 
 {{< callout >}}
-Introduced in 4.20.0
+Introduced in 4.20.0. This feature is only compatible with cht-android version `v1.5.2` or greater.
 {{< /callout >}}
 
 CHT `4.20.0` introduced the single sign on (SSO) feature allowing deployments to use the industry standard [OpenID Connect](https://openid.net/) (OIDC) protocol to authenticate users.  Below are some key points on the SSO functionality in the CHT. See the [technical design document](https://docs.google.com/document/d/1LUn1ZRetAmYE04CtdcTmp-bEBvl37AZ0CvFXZChXqfU/edit?tab=t.0) for all the details.


### PR DESCRIPTION
# Description

Now that cht-android `v1.5.2` is released with the fix for SSO login, we should add this to the relevant SSO documentation.

https://forum.communityhealthtoolkit.org/t/announcing-the-release-of-cht-android-app-v1-5-2/5094

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

