### PR TITLE
chore: exclude failing urls

### DIFF
--- a/.github/scripts/muffet.sh
+++ b/.github/scripts/muffet.sh
@@ -53,6 +53,8 @@
   --exclude "http[s]*://oppiamobile.readthedocs.io*." \
   --exclude "http[s]*://borgbackup.readthedocs.io.*" \
   --exclude "http[s]*://.*udemy.com.*" \
+  --exclude "http[s]*://docs.dhis2.org.*" \
+  --exclude "http[s]*://stackoverflow.com/questions.*" \
   --exclude "http[s]*://.*udacity.com.*" \
   --exclude "http[s]*://.*my.local-ip.co.*" \
   --exclude "http[s]*://.*local-ip.medicmobile.org.*" \


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Exclude `405` and `403` URLs per link checker script:

```
Run chmod +x ./.github/scripts/*muffet*
http://localhost:1313/building/integrations/dhis2-aggregate/
	405	https://docs.dhis2.org/2.34/en/dhis2_implementation_guide/data-elements-and-custom-dimensions.html#data-elements
	405	https://docs.dhis2.org/2.34/en/dhis2_implementation_guide/data-sets-and-forms.html#what-is-a-data-set
	405	https://docs.dhis2.org/2.34/en/dhis2_implementation_guide/integration-concepts.html#integration-concepts
	405	https://docs.dhis2.org/2.34/en/dhis2_implementation_guide/organisation-units.html
	405	https://docs.dhis2.org/master/en/developer/html/apps_creating_apps.html
	405	https://docs.dhis2.org/master/en/developer/html/webapi_data_values.html
http://localhost:[13](https://github.com/medic/cht-docs/commit/3fd9989718bc3488bf2797ce47eb8e15e62dfb81/checks#step:6:14)13/hosting/3.x/offline/
	403	https://stackoverflow.com/questions/6370017/mapping-a-hostname-to-an-ip-address-on-android
http://localhost:1313/building/integrations/dhis2/
	405	https://docs.dhis2.org/master/en/developer/html/apps_creating_apps.html
http://localhost:1313/building/guides/database/rdbms-from-windows/
	403	https://stackoverflow.com/questions/2224066/how-to-convert-ssh-keypairs-generated-using-puttygen-windows-into-key-pairs-us/2224[20](https://github.com/medic/cht-docs/commit/3fd9989718bc3488bf2797ce47eb8e15e62dfb81/checks#step:6:21)4#2224204
Error: Process completed with exit code 1.
```

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

