### PR TITLE
fix(#1866): optimize image sizes using Hextra cards for better responsive design

### DIFF
--- a/content/en/building/branding/application-graphics.md
+++ b/content/en/building/branding/application-graphics.md
@@ -8,8 +8,8 @@ relatedContent: >
   building/admin
   design/interface/icons
 aliases:
-   - /apps/tutorials/application-graphics
-   - /building/tutorials/application-graphics
+  - /apps/tutorials/application-graphics
+  - /building/tutorials/application-graphics
 ---
 
 This tutorial will take you through customising some graphical elements of CHT core.
@@ -26,13 +26,15 @@ You should have a functioning [CHT instance with `cht-conf` installed locally]({
 
 You have the ability to modify the app title, logo, and favicon. For Progressive Web App installations you can also configure the desktop icon.
 
-{{< figure src="branding_elements.png" link="branding_elements.png" class="center col-6 col-lg-8" >}}
+{{< cards cols="1" >}}
+{{< card image="branding_elements.png" method="Resize" options="600x q80 webp" >}}
+{{< /cards >}}
 
-| Variable | Description |
-|---|---|
-| **logo** | Should be less than 100KB, have a transparent background, have high contrast, and be horizontal in shape with a ratio of about 3.5:1. We recommend SVG or PNG image formats. |
-| **favicon** | Ideally 32x32 pixels, simple, and very small in size. We recommend SVG or PNG image formats. |
-| **icon** | Must be at least 192x192 pixels, square. We recommend SVG or PNG image formats. |
+| Variable    | Description                                                                                                                                                                  |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **logo**    | Should be less than 100KB, have a transparent background, have high contrast, and be horizontal in shape with a ratio of about 3.5:1. We recommend SVG or PNG image formats. |
+| **favicon** | Ideally 32x32 pixels, simple, and very small in size. We recommend SVG or PNG image formats.                                                                                 |
+| **icon**    | Must be at least 192x192 pixels, square. We recommend SVG or PNG image formats.                                                                                              |
 
 #### Using cht-conf
 
@@ -40,15 +42,15 @@ Create a `branding.json` file if it doesn't exist. (This may have already been c
 Edit the file with the following content:
 
 ```json
- {
-   "title": "My App Name",
-   "resources": {
-     "logo": "logo.png",
-     "favicon": "favicon.ico",
-     "icon": "pwa-icon.svg" // required for PWA installation only
-   }
- }
- ```
+{
+  "title": "My App Name",
+  "resources": {
+    "logo": "logo.png",
+    "favicon": "favicon.ico",
+    "icon": "pwa-icon.svg" // required for PWA installation only
+  }
+}
+```
 
 The folder and files structure would look like this:
 
@@ -78,24 +80,26 @@ Log in to your instance and navigate to `Menu > App Settings > Images > Icons`
 
 If you would like to display a collection of logos representing all of the organizations and funders involved in a project, there is a space for these at the bottom of the About page. This page can be accessed through; `Menu > About`
 
- {{< figure src="about_page.png" link="about_page.png" class="center col-6 col-lg-8" >}}
+{{< cards cols="1" >}}
+{{< card image="about_page.png" method="Resize" options="600x q80 webp" >}}
+{{< /cards >}}
 
- #### Using cht-conf
+#### Using cht-conf
 
 Create a `partners.json` file if it doesn't exist. (This may have already been created by the initialise-project-layout command).
 Edit the file with the following content:
 
 ```json
 {
-   "resources": {
-     "partnerA": "parnerA.png",
-     "partnerB": "parnerB.png",
-     "partnerC": "parnerC.png"
-   }
- }
- ```
+  "resources": {
+    "partnerA": "parnerA.png",
+    "partnerB": "parnerB.png",
+    "partnerC": "parnerC.png"
+  }
+}
+```
 
- The folder and files structure would look like this:
+The folder and files structure would look like this:
 
 ```shell
 ./
@@ -120,7 +124,6 @@ Log in to your instance and navigate to `Menu > App Settings > Images > Partners
 As of cht-core 3.10, app header tabs icons are configurable. CHT currently has five tabs: messages, tasks, reports, contacts, analytics.
 
 {{< see-also page="building/reference/app-settings/header_tabs" title="Header tabs" >}}
-
 
 #### Using cht-conf
 
@@ -171,14 +174,14 @@ Apps can be customised by defining the icons to use for tasks, targets, contacts
 Add icons to the `resources` folder, and include them by name in the `resources.json` file as the following example:
 
 ```json
- {
-    "icon-risk": "icon-healthcare-warning@2x.png",
-    "icon-treatment": "icon-healthcare-medicine@2x.png",
-    "medic-clinic": "medic-family.svg",
-    "medic-district-hospital": "medic-family.svg",
-    "medic-health-center": "medic-chw-area.svg",
-    "medic-person": "medic-person.svg"
- }
+{
+  "icon-risk": "icon-healthcare-warning@2x.png",
+  "icon-treatment": "icon-healthcare-medicine@2x.png",
+  "medic-clinic": "medic-family.svg",
+  "medic-district-hospital": "medic-family.svg",
+  "medic-health-center": "medic-chw-area.svg",
+  "medic-person": "medic-person.svg"
+}
 ```
 
 {{< see-also page="design/interface/icons" title="Icon Library" >}}
@@ -197,6 +200,7 @@ The folder and files structure would look like this:
         medic-person.svg
 
 ```
+
 Finally run the command: `cht --url=<instance-url> upload-resources`
 
 To modify the icon used in contacts, you will need to edit the icon subkey in app_settings.json (under contact_types). You will modify app_settings.json with the following contents:

--- a/content/en/building/contact-management/contact-and-users-1.md
+++ b/content/en/building/contact-management/contact-and-users-1.md
@@ -9,27 +9,27 @@ relatedContent: >
   technical-overview/concepts/db-schema
   building/guides/data/users-bulk-load
 aliases:
-   - /building/tutorials/contact-and-users-1/
-   - /apps/tutorials/contact-and-users-1
+  - /building/tutorials/contact-and-users-1/
+  - /apps/tutorials/contact-and-users-1
 ---
 
 In this tutorial you will learn how to create and edit contacts and their associated users in and application built with the CHT using the default contact creation forms. This will help you get familiar with the UI of the webapp as well as some features and functionality. If you are already comfortable with this, you can skip to [part 2, which covers manipulating contacts and their associated documents using cht-conf]({{% ref "building/contact-management/contact-and-users-2" %}}).
 
 ## Brief Overview of Key Concepts
 
-*Contacts* are people or places that are created in the CHT application.
+_Contacts_ are people or places that are created in the CHT application.
 
-*People* are both patients in the system and users of the system, such as CHWs or Nurses.
+_People_ are both patients in the system and users of the system, such as CHWs or Nurses.
 
-*Places* represent either an actual physical location such as a health facility, clinic, or a grouping such as a household or CHW Area.
+_Places_ represent either an actual physical location such as a health facility, clinic, or a grouping such as a household or CHW Area.
 
-*Contact forms* are forms in the CHT app that are used to create people or places.
+_Contact forms_ are forms in the CHT app that are used to create people or places.
 
-*CHT App Hierarchy* is often modeled after the health system, health program or community structure.  All people who are registered in the app must be associated with a Place. These Places are located in a hierarchy with other Places. For instance, a Family Member is part of a Household. A Household and CHWs are part of a CHW Area. A CHW Area and nurses are part of a Health Facility. Additional levels may be added as needed. The Admin level operates outside of the hierarchy and gives access to all levels and people.
+_CHT App Hierarchy_ is often modeled after the health system, health program or community structure. All people who are registered in the app must be associated with a Place. These Places are located in a hierarchy with other Places. For instance, a Family Member is part of a Household. A Household and CHWs are part of a CHW Area. A CHW Area and nurses are part of a Health Facility. Additional levels may be added as needed. The Admin level operates outside of the hierarchy and gives access to all levels and people.
 
 {{< figure src="app-hierarchy.jpg" link="app-hierarchy.jpg" caption="Default app hierarchy" >}}
 
-*Users* represent credentials and roles / permissions for accessing the application. This can either be:
+_Users_ represent credentials and roles / permissions for accessing the application. This can either be:
 
 - People who can log into the application, such as CHWs or Nurses or
 - Credentials granting external software restricted permissions to perform certain tasks, such as allowing an external service permission to write reports via the api.
@@ -44,39 +44,45 @@ In this tutorial, you will work with the default contact forms and the default h
 
 While logged in as an admin user, you will first create the Health Facility, CHW Supervisor, CHW Area, and CHW. You will then create the users for the CHW so that they can log in and create households and household members.
 
-
 ### 1. Create New Health Facility
 
-{{< figure src="new-facility/select-new-facility.png" link="new-facility/select-new-facility.png" class="right col-6 col-lg-8 bordered-figure" >}}
+{{< cards cols="1" >}}
+{{< card image="new-facility/select-new-facility.png" method="Resize" options="500x q80 webp" >}}
+{{< /cards >}}
 
 While logged into the CHT application, go to the **People tab** and select **New Health Facility**
 
-
-{{< figure src="new-facility/skip-primary-contact.png" link="new-facility/skip-primary-contact.png" class="right col-6 col-lg-8 bordered-figure" >}}
+{{< cards cols="1" >}}
+{{< card image="new-facility/skip-primary-contact.png" method="Resize" options="500x q80 webp" >}}
+{{< /cards >}}
 
 For now we will skip creating or assigning a primary contact so that we can focus on creating the new Health Facility.
 
-
-{{< figure src="new-facility/enter-facility-name.png" link="new-facility/enter-facility-name.png" class="right col-6 col-lg-8 bordered-figure" >}}
+{{< cards cols="1" >}}
+{{< card image="new-facility/enter-facility-name.png" method="Resize" options="500x q80 webp" >}}
+{{< /cards >}}
 
 Enter the details of the Health Facility and submit the form.
 
-
-{{< figure src="new-facility/created-facility.png" link="new-facility/created-facility.png" class="right col-6 col-lg-8 bordered-figure" >}}
+{{< cards cols="1" >}}
+{{< card image="new-facility/created-facility.png" method="Resize" options="500x q80 webp" >}}
+{{< /cards >}}
 
 You should see the newly created Health Facility appear on the left-hand side and when you select it, you will see details of the Health Facility appear on the right-hand side.
-
 
 ### 2. Create CHW Area and CHW
 
 We will now create a Place and the primary contact for it within one form. We want to create a CHW Area within the Health Facility that we previously created.
 
-
-{{< figure src="new-chw-area/new-chw-area-fab.png" link="new-chw-area/new-chw-area-fab.png" class="right col-6 col-lg-8 bordered-figure" >}}
+{{< cards cols="1" >}}
+{{< card image="new-chw-area/new-chw-area-fab.png" method="Resize" options="500x q80 webp" >}}
+{{< /cards >}}
 
 Select the **Health Facility** on the left-hand side. You will then select the Floating Action Button (FAB) that opens a menu with all actions.
 
-{{< figure src="new-chw-area/new-chw-area.png" link="new-chw-area/new-chw-area.png" class="right col-6 col-lg-8 bordered-figure" >}}
+{{< cards cols="1" >}}
+{{< card image="new-chw-area/new-chw-area.png" method="Resize" options="500x q80 webp" >}}
+{{< /cards >}}
 
 In the FAB menu select **New Area**.
 
@@ -84,21 +90,17 @@ In the FAB menu select **New Area**.
 
 Select the option that lets you create a new person within the form. This person will automatically become the primary contact for the created place.
 
-
 {{< figure src="new-chw-area/fill-required-fields.png" link="new-chw-area/fill-required-fields.png" class="right col-6 col-lg-8 bordered-figure" >}}
 
 Fill in the required fields and go to the next section.
-
 
 {{< figure src="new-chw-area/name-after-primary-contact.png" link="new-chw-area/name-after-primary-contact.png" class="right col-6 col-lg-8 bordered-figure" >}}
 
 You will get an option to name the Place after the created contact person or name it yourself. If you select **Yes**, the new place will be named `<contact-name>'s Area`. For example `Jane Doe's Area`.
 
-
 {{< figure src="new-chw-area/created-chw-area.png" link="new-chw-area/created-chw-area.png" class="right col-6 col-lg-8 bordered-figure" >}}
 
 Once you submit, a new CHW Area will be created. On the right-hand you should see the CHW Area name, the primary contact of the CHW Area, and the Health Facility that the CHW Area belongs to.
-
 
 ### 3. Create CHW Supervisor
 
@@ -108,13 +110,11 @@ To create a primary contact for an existing Place (in this case, for the Health 
 
 {{< figure src="new-chw-supervisor/belongs-to.png" link="new-chw-supervisor/belongs-to.png" class="right col-6 col-lg-8 bordered-figure" >}}
 
-A *new person form* will appear with an option to change the Place the new person will belong to. A new contact will be created in the Health Facility when you submit this form.
-
+A _new person form_ will appear with an option to change the Place the new person will belong to. A new contact will be created in the Health Facility when you submit this form.
 
 {{< figure src="new-chw-supervisor/edit-facility.png" link="new-chw-supervisor/edit-facility.png" class="right col-6 col-lg-8 bordered-figure" >}}
 
 Finally, we will set the newly created person as a primary contact for the Health Facility they belong to. To do this, select the Health Facility and then in the More Options (⋮) menu select the **Edit** action.
-
 
 {{< figure src="new-chw-supervisor/set-primary-contact.png" link="new-chw-supervisor/set-primary-contact.png" class="right col-6 col-lg-8 bordered-figure" >}}
 
@@ -124,11 +124,9 @@ You should see an edit form from which you can set the primary contact of the He
 
 You may want to log in as a CHW and perform some actions now that the CHW and CHW Supervisor contacts are created; let's create a CHW user who's linked to the CHW contact we created earlier.
 
-
 {{< figure src="new-chw-user/app-settings.png" link="new-chw-user/app-settings.png" class="right col-6 col-lg-8 bordered-figure" >}}
 
 Go to the **hamburger menu** and select **App Settings**.
-
 
 {{< figure src="new-chw-user/add-user.png" link="new-chw-user/add-user.png" class="right col-6 col-lg-8 bordered-figure" >}}
 
@@ -139,7 +137,6 @@ When you are on the **App Settings** page, select **Users** on the left-hand sid
 You should now see an **Add User Form**. Fill in the user name, then select the role as **CHW** or **Regional Admin**. In the **Place** field, select the name of the CHW Area whose CHW you want to create a user for (you can search by typing the first few letters of the CHW Area name). Once that is done, under the **Associate Contact** field select the name of the CHW whose user you are creating. Finally, input a password and hit **Submit**.
 
 Once this is done, you can logout and log into the app using the username and password that you just created.
-
 
 ## Frequently Asked Questions
 

--- a/content/en/building/contact-management/contacts.md
+++ b/content/en/building/contact-management/contacts.md
@@ -11,9 +11,10 @@ relatedContent: >
   building/contact-management/contact-and-users-1
   reference-apps/contact-tracing
 aliases:
-   - /building/features/contacts/
-   - /apps/features/contacts/
+  - /building/features/contacts/
+  - /apps/features/contacts/
 ---
+
 <!-- ## Contacts: Person and Family Profiles -->
 <!-- TODO Refine screenshots, and add desktop view. -->
 
@@ -23,14 +24,15 @@ aliases:
 
 Users can access their “people” and “places” from the **People** tab. The permissions set for your role and your placement in the hierarchy will determine which contacts you’re able to see. Advanced configuration options are available for a specific offline user role to manage what [level of contact data]({{< ref "building/guides/performance/replication#contact-depth" >}}) is downloaded and stored on their device.
 
-
-{{< figure src="people-desktop.png" link="people-desktop.png" class="right col-6 col-lg-8 bordered-figure" >}}
+{{< cards cols="1" >}}
+{{< card image="people-desktop.png" method="Resize" options="600x q80 webp" >}}
+{{< /cards >}}
 
 ## Main List
 
-{{< cards >}}
-  {{< figure src="people-mobile.png" link="people-mobile.png" class="right col-6 col-lg-8 bordered-figure" >}}
-  {{< figure src="sort-dropdown.png" link="sort-dropdown.png" class="right col-6 col-lg-8 bordered-figure" >}}
+{{< cards cols="2" >}}
+{{< card image="people-mobile.png" method="Resize" options="400x q80 webp" >}}
+{{< card image="sort-dropdown.png" method="Resize" options="400x q80 webp" >}}
 {{< /cards >}}
 
 The list view on the leftmost screenshot is what a logged-in CHW would see when they access the “People” tab on a small screen.
@@ -45,8 +47,8 @@ With the [_UHC Mode_]({{< relref "building/uhc-mode" >}}) configured, the main l
 
 ## Searching
 
-{{< cards >}}
-{{< figure src="search-mobile.png" link="search-mobile.png" class="right col-6 col-lg-8 bordered-figure" >}}
+{{< cards cols="1" >}}
+{{< card image="search-mobile.png" method="Resize" options="400x q80 webp" >}}
 {{< /cards >}}
 
 Click on the search icon at the top of the screen to search for a “person” or “place”. The freetext search works on all fields included in the “person” or “place” document such as patient name or patient ID. The exact fields depends on which information you’ve configured your app to collect.
@@ -63,11 +65,11 @@ If you’re viewing a place profile, you’ll see a list of people or places tha
 
 Beneath that, you will find tasks for this person or place. At the very bottom is a history of submitted reports for this person or place.
 
-{{< cards rows="4" >}}
-{{< figure src="profile1.png" link="profile1.png" class="right col-6 col-lg-8 bordered-figure" >}}
-{{< figure src="profile2.png" link="profile2.png" class="right col-6 col-lg-8 bordered-figure" >}}
-{{< figure src="profile3.png" link="profile3.png" class="right col-6 col-lg-8 bordered-figure" >}}
-{{< figure src="profile4.png" link="profile4.png" class="right col-6 col-lg-8 bordered-figure" >}}
+{{< cards cols="2" >}}
+{{< card image="profile1.png" method="Resize" options="400x q80 webp" >}}
+{{< card image="profile2.png" method="Resize" options="400x q80 webp" >}}
+{{< card image="profile3.png" method="Resize" options="400x q80 webp" >}}
+{{< card image="profile4.png" method="Resize" options="400x q80 webp" >}}
 {{< /cards >}}
 
 From profiles, users can edit contact information, take actions, and, if viewing a place profile, add new people and assign a primary contact person. If a place is not at the bottom of the hierarchy, a user can add new places to the level below this.
@@ -83,7 +85,6 @@ The top card on all profiles contains general information for the contact. All t
 {{< figure link="bio2.png" src="bio2.png" class="right col-6 col-lg-8 bordered-figure" >}}
 {{< /cards >}}
 
-
 {{< see-also page="contact-summary-templated" anchor="contact-summary" title="Defining Contact Summary" >}}
 
 ### Condition Cards
@@ -93,6 +94,7 @@ A “condition” card displays data on a profile that’s been submitted in a r
 Condition cards can be permanent or conditional; set to appear only when a specific type of report is submitted. They can also be set to disappear when a condition is resolved or a certain amount of time has passed. You can have as many condition cards as you like, though we recommend keeping the user’s experience in mind.
 
 Configurable elements include:
+
 - Title
 - Label for each data point displayed
 - Data point for the field
@@ -106,14 +108,13 @@ Configurable elements include:
 
 {{< see-also page="contact-summary-templated" anchor="condition-cards" title="Defining Condition Cards" >}}
 
-
 ## Care Guides
+
 <!-- todo: Resolve Care Guides vs Actions -->
 
 {{< cards rows="1" >}}
 {{< figure link="care-guides.png" src="care-guides.png" class="right col-6 col-lg-8 bordered-figure" >}}
 {{< /cards >}}
-
 
 “Care Guides” are dynamic forms that you can fill out for a person or place. You can access Care Guides by clicking on the + button at the bottom of a profile. For more info, see the [Care Guides overview page]({{% ref care-guides %}}).
 
@@ -122,7 +123,6 @@ You’ll see different forms here depending on which person or place you’re vi
 Health workers can use these Care Guides at any time. If the app has scheduled a care visit or follow up, it will be listed under “Tasks.”
 
 {{< see-also page="contact-summary-templated" anchor="care-guides" title="Defining Care Guides" >}}
-
 
 ## Creating and Editing Contacts
 
@@ -138,8 +138,6 @@ _(Added in CHT `4.19.0`)_
 
 One major challenge when collecting contact data is ensuring users do not inadvertently enter duplicate records for the same contact. It is important to train users on the [searching]({{< ref "#searching" >}}) functionality described above as this will allow them to find the desired profile of a previously recorded contact instead of creating a duplicate record for the same person or place.
 
- The CHT also supports automatically detecting when a contact being created or edited by a user matches an existing contact record. If a duplicate contact is detected, the user will be given the option of proceeding to the profile of the existing contact. Alternatively, the user can choose to override the duplicate detection logic and continue creating/editing the contact as originally intended.
+The CHT also supports automatically detecting when a contact being created or edited by a user matches an existing contact record. If a duplicate contact is detected, the user will be given the option of proceeding to the profile of the existing contact. Alternatively, the user can choose to override the duplicate detection logic and continue creating/editing the contact as originally intended.
 
 The matching logic for duplicate detection is [configurable]({{< relref "building/forms/contact#properties" >}}) and can be tuned to the specific needs and data structures of a particular project. The algorithm compares the created/edited contact _to its sibling contacts._ These are other contacts of the same type that share the same parent contact. By default, contacts are considered duplicates if they have very similar names AND (for persons) if they are the same age (in years). This default logic can be overridden with custom logic for each type of contact.
-
-

--- a/content/en/building/targets/targets-js.md
+++ b/content/en/building/targets/targets-js.md
@@ -9,18 +9,18 @@ relatedContent: >
   design/best-practices
 keywords: targets workflows
 aliases:
-   - /building/reference/targets/
-   - /apps/reference/targets
+  - /building/reference/targets/
+  - /apps/reference/targets
 ---
 
-{{< cards >}}
-  {{< figure src="count_1.png" link="count_1.png" class="right col-6 col-lg-8 bordered-figure" >}}
-  {{< figure src="count_2.png" link="count_2.png" class="right col-6 col-lg-8 bordered-figure" >}}
+{{< cards cols="2" >}}
+{{< card image="count_1.png" method="Resize" options="400x q80 webp" >}}
+{{< card image="count_2.png" method="Resize" options="400x q80 webp" >}}
 {{< /cards >}}
 
-{{< cards >}}
-  {{< figure src="percentage_1.png" link="percentage_1.png" class="right col-6 col-lg-8 bordered-figure" >}}
-  {{< figure src="percentage_2.png" link="percentage_2.png" class="right col-6 col-lg-8 bordered-figure" >}}
+{{< cards cols="2" >}}
+{{< card image="percentage_1.png" method="Resize" options="400x q80 webp" >}}
+{{< card image="percentage_2.png" method="Resize" options="400x q80 webp" >}}
 {{< /cards >}}
 
 All targets are defined in the `targets.js` file as an array of objects according to the Targets schema defined below. Each object corresponds to a target widget that shows in the app. The order of objects in the array defines the display order of widgets on the Targets tab. The properties of the object are used to define when the target should appear, what it should look like, and the values it will display.
@@ -29,35 +29,37 @@ All targets are defined in the `targets.js` file as an array of objects accordin
 
 ## `targets.js`
 
-| property | type | description | required |
-|---|---|---|---|
-| `id` | `string` | An identifier for the target. | yes, unique |
-| `icon` | `string` | The icon to show alongside the target. Should correspond with a value defined in `resources.json`. | no |
-| `translation_key` | `translation key` | Translation key for the title of this target. | no, but recommended |
-| `subtitle_translation_key` | `translation key` | Translation key for the subtitle of this target. If none supplied the subtitle will be blank. | no |
-| `percentage_count_translation_key` | `translation key` | Translation key for the percentage value detail shown at the bottom of the target, eg "(5 of 6 deliveries)". The translation context has `pass` and `total` variables available. If none supplied this defaults to `targets.count.default`. | no |
-| `context` | `string` | A string containing a JavaScript expression. This widget will only be shown if the expression evaluates to true. Details of the current user is available through the variable `user`. | no |
-| `type` | `'count'` or `'percent'` | The type of the widget. | yes |
-| `goal` | `integer` | For targets with `type: 'percent'`, an integer from 0 to 100. For `type: 'count'`, any positive number. If there is no goal, put -1. | yes |
-| `appliesTo` | `'contacts'` or `'reports'` | Do you want to count reports or contacts? This attribute controls the behavior of other attributes herein. | yes |
-| `appliesToType` | If `appliesTo: 'reports'`, an array of form codes. If `appliesTo: 'contacts'`, an array of contact types. | Filters the contacts or reports for which `appliesIf` will be evaluated. For example, `['person']` or `['clinic', 'health_center']`. For example, `['pregnancy']` or `['P', 'pregnancy']`. | no |
-| `appliesIf` | `function(contact, report)` | If `appliesTo: 'contacts'`, this function is invoked once per contact and `report` is undefined. If `appliesTo: 'reports'`, this function is invoked once per report. Return true to count this document. For `type: 'percent'`, this controls the denominator. | no |
-| `passesIf` | `function(contact, report)` | For `type: 'percent'`, return true to increment the numerator. | yes, if `type: 'percent'`. Forbidden when `groupBy` is defined. |
-| `date` | `'reported'` or `'now'` or `function(contact, report)` | When `'reported'`, the target will count documents with a `reported_date` within the current month. When `'now'`, target includes all documents. A function can be used to indicate when the document should be counted. When this property is undefined or the value is null the default is 'now'. | no |
-| `idType` | `'report'` or `'contact'` or `function(contact, report)` | The target's values are incremented once per unique ID. To count individual contacts that have one or more reports that apply, use `'contact'`. Use `'report'` to count all reports, even if there are multiple that apply for a single contact. If you need more than a single count for each applying contact or report then a custom function can be used returning an array with unique IDs — one element for each count. | no |
-| `groupBy` | `function(contact, report)` returning string | Allows for target ids to be aggregated and scored in groups. Not required for most targets. Use with passesIfGroupCount. | no |
-| `passesIfGroupCount` | `object` | The criteria to determine if the target ids within a group should be counted as passing | yes when `groupBy` is defined |
-| `passesIfGroupCount.gte` | `number` | The group should be counted as passing if the number of target ids in the group is greater-than-or-equal-to this value | yes when `groupBy` is defined |
-| `dhis` | `object` or `object[]` | Settings relevant to the [DHIS2 Integration]({{< ref "building/integrations/dhis2-aggregate#configuration" >}}) | no
-| `dhis[n].dataElement` | `string` | The hash id of a data element configured in the DHIS2 data set you're integrating with | yes
-| `dhis[n].dataSet` | `string` | The hash id of the data set that contains the data element you're integrating with. If this is left undefined, the data element will appear in all data sets. | no
-| `visible` | `boolean` | Whether the target is visible in the targets page. **Default: true** | no |
-| `aggregate` | `boolean` | As of 3.9, defines whether the target will be displayed on the TargetAggregates page | no |
+| property                           | type                                                                                                      | description                                                                                                                                                                                                                                                                                                                                                                                                                   | required                                                        |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `id`                               | `string`                                                                                                  | An identifier for the target.                                                                                                                                                                                                                                                                                                                                                                                                 | yes, unique                                                     |
+| `icon`                             | `string`                                                                                                  | The icon to show alongside the target. Should correspond with a value defined in `resources.json`.                                                                                                                                                                                                                                                                                                                            | no                                                              |
+| `translation_key`                  | `translation key`                                                                                         | Translation key for the title of this target.                                                                                                                                                                                                                                                                                                                                                                                 | no, but recommended                                             |
+| `subtitle_translation_key`         | `translation key`                                                                                         | Translation key for the subtitle of this target. If none supplied the subtitle will be blank.                                                                                                                                                                                                                                                                                                                                 | no                                                              |
+| `percentage_count_translation_key` | `translation key`                                                                                         | Translation key for the percentage value detail shown at the bottom of the target, eg "(5 of 6 deliveries)". The translation context has `pass` and `total` variables available. If none supplied this defaults to `targets.count.default`.                                                                                                                                                                                   | no                                                              |
+| `context`                          | `string`                                                                                                  | A string containing a JavaScript expression. This widget will only be shown if the expression evaluates to true. Details of the current user is available through the variable `user`.                                                                                                                                                                                                                                        | no                                                              |
+| `type`                             | `'count'` or `'percent'`                                                                                  | The type of the widget.                                                                                                                                                                                                                                                                                                                                                                                                       | yes                                                             |
+| `goal`                             | `integer`                                                                                                 | For targets with `type: 'percent'`, an integer from 0 to 100. For `type: 'count'`, any positive number. If there is no goal, put -1.                                                                                                                                                                                                                                                                                          | yes                                                             |
+| `appliesTo`                        | `'contacts'` or `'reports'`                                                                               | Do you want to count reports or contacts? This attribute controls the behavior of other attributes herein.                                                                                                                                                                                                                                                                                                                    | yes                                                             |
+| `appliesToType`                    | If `appliesTo: 'reports'`, an array of form codes. If `appliesTo: 'contacts'`, an array of contact types. | Filters the contacts or reports for which `appliesIf` will be evaluated. For example, `['person']` or `['clinic', 'health_center']`. For example, `['pregnancy']` or `['P', 'pregnancy']`.                                                                                                                                                                                                                                    | no                                                              |
+| `appliesIf`                        | `function(contact, report)`                                                                               | If `appliesTo: 'contacts'`, this function is invoked once per contact and `report` is undefined. If `appliesTo: 'reports'`, this function is invoked once per report. Return true to count this document. For `type: 'percent'`, this controls the denominator.                                                                                                                                                               | no                                                              |
+| `passesIf`                         | `function(contact, report)`                                                                               | For `type: 'percent'`, return true to increment the numerator.                                                                                                                                                                                                                                                                                                                                                                | yes, if `type: 'percent'`. Forbidden when `groupBy` is defined. |
+| `date`                             | `'reported'` or `'now'` or `function(contact, report)`                                                    | When `'reported'`, the target will count documents with a `reported_date` within the current month. When `'now'`, target includes all documents. A function can be used to indicate when the document should be counted. When this property is undefined or the value is null the default is 'now'.                                                                                                                           | no                                                              |
+| `idType`                           | `'report'` or `'contact'` or `function(contact, report)`                                                  | The target's values are incremented once per unique ID. To count individual contacts that have one or more reports that apply, use `'contact'`. Use `'report'` to count all reports, even if there are multiple that apply for a single contact. If you need more than a single count for each applying contact or report then a custom function can be used returning an array with unique IDs — one element for each count. | no                                                              |
+| `groupBy`                          | `function(contact, report)` returning string                                                              | Allows for target ids to be aggregated and scored in groups. Not required for most targets. Use with passesIfGroupCount.                                                                                                                                                                                                                                                                                                      | no                                                              |
+| `passesIfGroupCount`               | `object`                                                                                                  | The criteria to determine if the target ids within a group should be counted as passing                                                                                                                                                                                                                                                                                                                                       | yes when `groupBy` is defined                                   |
+| `passesIfGroupCount.gte`           | `number`                                                                                                  | The group should be counted as passing if the number of target ids in the group is greater-than-or-equal-to this value                                                                                                                                                                                                                                                                                                        | yes when `groupBy` is defined                                   |
+| `dhis`                             | `object` or `object[]`                                                                                    | Settings relevant to the [DHIS2 Integration]({{< ref "building/integrations/dhis2-aggregate#configuration" >}})                                                                                                                                                                                                                                                                                                               | no                                                              |
+| `dhis[n].dataElement`              | `string`                                                                                                  | The hash id of a data element configured in the DHIS2 data set you're integrating with                                                                                                                                                                                                                                                                                                                                        | yes                                                             |
+| `dhis[n].dataSet`                  | `string`                                                                                                  | The hash id of the data set that contains the data element you're integrating with. If this is left undefined, the data element will appear in all data sets.                                                                                                                                                                                                                                                                 | no                                                              |
+| `visible`                          | `boolean`                                                                                                 | Whether the target is visible in the targets page. **Default: true**                                                                                                                                                                                                                                                                                                                                                          | no                                                              |
+| `aggregate`                        | `boolean`                                                                                                 | As of 3.9, defines whether the target will be displayed on the TargetAggregates page                                                                                                                                                                                                                                                                                                                                          | no                                                              |
 
 ## Utils
+
 {{< read-content file="building/reference/_partial_utils.md" >}}
 
 ## CHT API
+
 {{< read-content file="building/reference/_partial_cht_api.md" >}}
 
 ## Code Samples
@@ -65,79 +67,84 @@ All targets are defined in the `targets.js` file as an array of objects accordin
 This sample `targets.js` generates three widgets, and uses functions written in the `targets-extras.js` file.
 
 ### `targets.js`
+
 ```js
-const { isHealthyDelivery, countReportsSubmittedInWindow } = require('./targets-extras');
+const { isHealthyDelivery, countReportsSubmittedInWindow } = require("./targets-extras");
 
 module.exports = [
   // BIRTHS THIS MONTH
   {
-    id: 'births-this-month',
-    type: 'count',
-    icon: 'infant',
+    id: "births-this-month",
+    type: "count",
+    icon: "infant",
     goal: -1,
-    translation_key: 'targets.births.title',
-    subtitle_translation_key: 'targets.this_month.subtitle',
+    translation_key: "targets.births.title",
+    subtitle_translation_key: "targets.this_month.subtitle",
 
-    appliesTo: 'reports',
+    appliesTo: "reports",
     appliesIf: isHealthyDelivery,
-    date: 'reported',
+    date: "reported",
   },
 
   // % DELIVERIES ALL TIME WITH 1+ VISITS
   {
-    id: 'delivery-with-min-1-visit',
-    type: 'percent',
-    icon: 'nurse',
+    id: "delivery-with-min-1-visit",
+    type: "percent",
+    icon: "nurse",
     goal: 100,
-    translation_key: 'targets.delivery_1_visit.title',
-    subtitle_translation_key: 'targets.all_time.subtitle',
+    translation_key: "targets.delivery_1_visit.title",
+    subtitle_translation_key: "targets.all_time.subtitle",
 
-    appliesTo: 'reports',
-    idType: 'report',
+    appliesTo: "reports",
+    idType: "report",
     appliesIf: isHealthyDelivery,
-    passesIf: function(c, r) {
-      var visits = countReportsSubmittedInWindow(c.reports, antenatalForms, r.reported_date - MAX_DAYS_IN_PREGNANCY*MS_IN_DAY, r.reported_date);
+    passesIf: function (c, r) {
+      var visits = countReportsSubmittedInWindow(
+        c.reports,
+        antenatalForms,
+        r.reported_date - MAX_DAYS_IN_PREGNANCY * MS_IN_DAY,
+        r.reported_date
+      );
       return visits > 0;
     },
-    date: 'now',
+    date: "now",
   },
 
   {
-    id: '2-home-visits-per-family',
-    icon: 'home-visit',
-    type: 'percent',
+    id: "2-home-visits-per-family",
+    icon: "home-visit",
+    type: "percent",
     goal: 100,
     translation_key: `target.2-home-visits-per-family`,
     context: 'user.role === "chw"',
-    date: 'reported',
+    date: "reported",
 
-    appliesTo: 'contacts',
-    appliesToType: 'person',
-    idType: contact => {
+    appliesTo: "contacts",
+    appliesToType: "person",
+    idType: (contact) => {
       // Determines the target ids which will be in the group.
       // eg. "family1~2000-02-15" and "family1~2000-02-16"
-      const householdVisitDates = new Set(contact.reports.map(report => toDateString(report.reported_date)));
+      const householdVisitDates = new Set(contact.reports.map((report) => toDateString(report.reported_date)));
       const familyId = contact.contact.parent._id;
-      return Array.from(householdVisitDates).map(date => `${familyId}~${date}`);
+      return Array.from(householdVisitDates).map((date) => `${familyId}~${date}`);
     },
-    groupBy: contact => contact.contact.parent._id,
+    groupBy: (contact) => contact.contact.parent._id,
     passesIfGroupCount: { gte: 2 },
-  }
-]
-
+  },
+];
 ```
 
 ### `targets-extras.js`
+
 ```js
 module.exports = {
   isHealthyDelivery(c, r) {
-    return r.form === 'D' ||
-        (r.form === 'delivery' && r.fields.pregnancy_outcome === 'healthy');
+    return r.form === "D" || (r.form === "delivery" && r.fields.pregnancy_outcome === "healthy");
   },
 
   countReportsSubmittedInWindow(reports, form, start, end) {
     var reportsFound = 0;
-    reports.forEach(function(r) {
+    reports.forEach(function (r) {
       if (form.indexOf(r.form) >= 0) {
         if (r.reported_date >= start && r.reported_date <= end) {
           reportsFound++;

--- a/content/en/building/targets/targets-overview.md
+++ b/content/en/building/targets/targets-overview.md
@@ -9,18 +9,17 @@ relatedContent: >
   building/integrations/dhis2
   building/supervision/#chw-aggregate-targets
 aliases:
-   - /building/features/targets/
-   - /apps/features/targets/
+  - /building/features/targets/
+  - /apps/features/targets/
 ---
 
-*Targets* is the user dashboard or analytics tab. The widgets on this tab provide a summary or analysis of the data in submitted reports. These widgets can be configured to track metrics for an individual CHW, for a Supervisor overseeing a group of CHWs, or for an entire health facility.
+_Targets_ is the user dashboard or analytics tab. The widgets on this tab provide a summary or analysis of the data in submitted reports. These widgets can be configured to track metrics for an individual CHW, for a Supervisor overseeing a group of CHWs, or for an entire health facility.
 
 For CHWs, the **Targets** tab provides a quick summary of their progress towards their individual goals. For Supervisors, Nurses, and facility-based users, the **Targets** tab provides important insights into how their community unit is performing.
 
-{{< figure src="targets-desktop.png" link="targets-desktop.png" class="right col-6 col-lg-8 bordered-figure" >}}
-
-{{< cards rows="1" >}}
-{{< figure src="targets-mobile.png" link="targets-mobile.png" class="right col-6 col-lg-8 bordered-figure" >}}
+{{< cards cols="2" >}}
+{{< card image="targets-desktop.png" method="Resize" options="500x q80 webp" >}}
+{{< card image="targets-mobile.png" method="Resize" options="500x q80 webp" >}}
 {{< /cards >}}
 
 > [!IMPORTANT]
@@ -28,15 +27,14 @@ For CHWs, the **Targets** tab provides a quick summary of their progress towards
 
 ## Types of Widgets
 
-There are two basic types of widgets: count and percent. *Count widgets* display a numeric sum while *percent widgets* display progress towards achieving a target.
+There are two basic types of widgets: count and percent. _Count widgets_ display a numeric sum while _percent widgets_ display progress towards achieving a target.
 
 The text, icon, goal, and time frame of each widget is easily configured. The time frame is set per widget, and set to show values for "this month" (resets back to zero at the beginning of each month) or "all time" (a cumulative total).
-
 
 ### Count Widgets
 
 {{< cards >}}
-  {{< figure src="targets-count.png" link="targets-count.png" class="right col-7 col-lg-4" >}}
+{{< figure src="targets-count.png" link="targets-count.png" class="right col-7 col-lg-4" >}}
 {{< /cards >}}
 
 Count widgets show a tally of a particular report that has been submitted or data within a report that matches a set of criteria. For example, a count can be done for the number of new pregnancies, the number of facility-based deliveries, or the number of households registered that month.
@@ -46,7 +44,7 @@ A count without a goal displays a simple green number count. A count with a goal
 ### Percent Widgets
 
 {{< cards >}}
-  {{< figure src="targets-percentage.png" link="targets-percentage.png" class="right col-7 col-lg-4" >}}
+{{< figure src="targets-percentage.png" link="targets-percentage.png" class="right col-7 col-lg-4" >}}
 {{< /cards >}}
 
 Percent widgets display a ratio, which helps to provide insight into the proportion that matches a defined criteria. For example, the proportion of newborns delivered in a facility can be presented as a percent with respect to all registered deliveries.


### PR DESCRIPTION
# Description

Fixes oversized images across Build section by implementing Hextra cards shortcode as recommended in [#1866](https://github.com/medic/cht-docs/issues/1866).

## Problem

• Many images used `class="right col-6 col-lg-8 bordered-figure"` making them 2/3 screen width on large screens
• Mixed usage of `{{< cards >}}` containing `{{< figure >}}` elements instead of proper card syntax
• No image optimization or processing capabilities utilized
• Inconsistent responsive behavior and poor readability on large screens

## Solution

• **Contacts section**: Converted oversized figures to proper `{{< card image="..." >}}` syntax with optimization
• **Branding pages**: Replaced large centered images with responsive cards
• **Targets sections**: Fixed mixed cards/figures usage and implemented consistent layout
• **Contact management**: Optimized facility creation and CHW area screenshots
• **Image processing**: Added automatic resize, quality control (80%), and WebP conversion

All images now use Hextra's built-in image optimization with appropriate sizing
instead of taking up excessive screen real estate.

## Testing

• Hugo builds without errors using `docker compose up hugo`
• All card images display with proper responsive sizing
• Image optimization working: automatic WebP conversion and resizing
• Layout matches Design section pattern established in CHT docs
• Tested on multiple pages: contacts, branding, targets sections

## Files Changed

• `content/en/building/contact-management/contacts.md` - Fixed profile images and main list screenshots
• `content/en/building/contact-management/contact-and-users-1.md` - Optimized facility creation workflow images
• `content/en/building/branding/application-graphics.md` - Fixed branding elements and about page images  
• `content/en/building/targets/targets-overview.md` - Corrected mixed cards/figures usage
• `content/en/building/targets/targets-js.md` - Fixed count and percentage widget screenshots

# License

The software is provided under AGPL-3.0. Contributions to this project are
accepted under the same license.