### PR TITLE
chore(na): removing line breaks so tickets look good

### DIFF
--- a/content/en/community/contributing/creating-good-first-issues.md
+++ b/content/en/community/contributing/creating-good-first-issues.md
@@ -27,11 +27,7 @@ Use this content to paste into a GitHub ticket.  Then add the steps needed to so
 ```markdown
 ## Good first issue
 
-This ticket has the
-[Good first issue label](https://github.com/medic/cht-core/issues?q=state%3Aopen%20label%3A%22Good%20first%20issue%22)!
-This means it's been especially curated by other CHT contributors to be easy to work
-on for first time contributors
-[per the docs](https://docs.communityhealthtoolkit.org/community/contributing/creating-good-first-issues/).
+This ticket has the [Good first issue label](https://github.com/medic/cht-core/issues?q=state%3Aopen%20label%3A%22Good%20first%20issue%22)! This means it's been especially curated by other CHT contributors to be easy to work on for first time contributors [per the docs](https://docs.communityhealthtoolkit.org/community/contributing/creating-good-first-issues/).
 
 To succeed on this ticket, please:
 1. step one


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Tickets created from the new template on good first issue page don't like the line breaks.  removing them!

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

