### PR TITLE
Docs: Update task priority label to use translation keys

### DIFF
--- a/content/en/building/tasks/tasks-js.md
+++ b/content/en/building/tasks/tasks-js.md
@@ -132,7 +132,7 @@ module.exports = [
     } ],
     priority: {
       level: 'high',
-      label: [ { locale:'en', content:'Home Birth' } ],
+      label: 'task.priority.label.home_birth',
     },
     resolvedIf: function(c, r, event, dueDate) {
       // Resolved if there a visit report received in time window or a newer pregnancy


### PR DESCRIPTION
Updates the `tasks.js` documentation to reflect the correct method for internationalizing task priority labels.

- Replaces the outdated array-style label with the recommended translation key (string) format.
- Adds an explanatory note clarifying that using translation keys is the standard practice for internationalization.

This change aligns the documentation with the current validation schema in `cht-conf`.

Fixes #1974