### PR TITLE
feat: update "Good First Issue" link to filter out assigned issues

### DIFF
--- a/content/en/community/contributing/first-time-contributors.md
+++ b/content/en/community/contributing/first-time-contributors.md
@@ -32,9 +32,7 @@ If you have never used `git` or GitHub, check out the [Get started using GitHub 
 
 ## Your first issue
 
-Issues marked [Good first issue](https://github.com/medic/cht-core/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22Good%20first%20issue%22) could be a great start if you are new to the CHT. Feel free to pick an issue that looks easy for you! An easy-looking issue will better set you up for successfully merging the code. Easy merges are our goal here!
-
-Feel free to look beyond just the CHT Core as well - we have other repositories that [also have the Good first issue label](https://github.com/search?q=org%3Amedic+label%3A%22Good+first+issue%22++&type=issues&state=open).
+Issues marked [Good first issue](https://github.com/search?q=org%3Amedic+label%3A%22Good+first+issue%22+++no%3Aassignee&type=issues&state=open) could be a great start if you are new to the CHT. Feel free to pick an issue that looks easy for you! An easy-looking issue will better set you up for successfully merging the code. Easy merges are our goal here!
 
 Make a comment on the issue asking for the issue to be assigned to you.
 


### PR DESCRIPTION
# Description

When browsing the search results for "Good First Issues", there is no indication in the list of which issues are already assigned (and being worked on).  So, I updated the link to include the `no:assignee` filter so the only issues you see are open ones that are free to be worked on.

Also, it seems like there is no reason to emphasize issues in cht-core over other repos (and often the issues from other repos might make "better" first issues than starting out with a change to cht-core... :sweat_smile: So, I removed the redundant link to cht-core issues.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

