### PR TITLE
chore(#2006): change flexsearch tokenize to full

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -184,7 +184,7 @@ osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|HOME|ASDF_DIR)$'
 
     [params.search.flexsearch]
     index = "content"
-    tokenize = "forward"
+    tokenize = "full"
 
   [params.editURL]
   enable = true


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Change `flexsearch` `tokenize` parameter to `full` to increase the number of results returned by the search.

Per [documentation](https://github.com/nextapps-de/flexsearch#tokenizer-partial-match) + [additional documentation](https://lotusdocs.dev/docs/features/flexsearch/): 

- `strict` - Only exact matches for the search term will be shown in the results.
- `forward` (default) - Words are searched for starting from the first letter in a forward order, allowing partial matches to be displayed; unfinished words or words with mispellings at the end will still display results e.g. if searching for ‘Testing’, entering only ‘Tes’ will provide some results.
- `reverse` - A result will be shown when the letters of the search term occur in both forward or reverse order, provide even more support for mispellings or incomplete searches e.g. if searching for ‘Testing’, entering either ‘Tes’ or ‘ing’ will provide some results.
- `full` - Combines all of the above, plus partial matches for the middle section of the search term e.g. if searching for ‘Testing’, entering either ‘Tes’, ‘ing’ or ‘sti’, or other combinations thereof will provide some results.

#2006 

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

