### PR TITLE
fix: correct docs to say targets only enabled for offline users

### DIFF
--- a/content/en/building/supervision/chw-aggregate-targets.md
+++ b/content/en/building/supervision/chw-aggregate-targets.md
@@ -14,7 +14,7 @@ For CHW Supervisors, the [Targets]({{< relref "building/targets/targets-overview
 Selecting an aggregate widget opens the detailed view with the data for each individual CHW. If a CHW is performing below the target goal, their value will be highlighted in red, making it easier for Supervisors to know with which CHWs to follow up for coaching and performance management.
 
 > [!NOTE]
-> Aggregate targets were introduced in v3.9, and can be configured for both online and offline users. Aggregate targets are based on the widgets seen by CHWs, and dependent on the data that has been synced. If a CHW or the supervisor has not synced, then the aggregate target will not be up to date.
+> Aggregate targets were introduced in v3.9, and can be configured for offline users. Aggregate targets are based on the widgets seen by CHWs, and dependent on the data that has been synced. If a CHW or the supervisor has not synced, then the aggregate target will not be up to date.
 
 ### Filtering Aggregate Targets
 


### PR DESCRIPTION
# Description

The current documentation for aggregate targets says they "can be configured for both online and offline users".

However, I don't think this is true.  In the targets component we [check if the rules engine service is enabled](https://github.com/medic/cht-core/blob/1098e344a8d71ae5dd5570b17bb34312689e0f87/webapp/src/ts/modules/analytics/analytics-targets.component.ts#L95) (and otherwise show a message saying 

<img width="1680" height="401" alt="image" src="https://github.com/user-attachments/assets/4bd7f9e0-3a8a-4aaf-8c90-4a8f4bceb40b" />

If you have an online user, the [rules engine service always says it is disabled](https://github.com/medic/cht-core/blob/da5fe7f731303c6f69315b3992455125f539f91a/webapp/src/ts/services/rules-engine.service.ts#L101).

Am I missing something here? :thinking: This same should be true for aggregate targets, right?  Cannot see aggregate targets if you cannot see any targets....

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

