### PR TITLE
chore(#1834): update backup docs

### DIFF
--- a/content/en/hosting/cht/docker/backups.md
+++ b/content/en/hosting/cht/docker/backups.md
@@ -36,25 +36,18 @@ Create a backup directory called `backup` in the `cht` directory:
 mkdir /home/ubuntu/cht/backup
 ```
 
-### Backup `.env`
+### Backup `.env` and CouchDB 
 
-Copy the `.env` to the newly created directory:  
-
-```shell
-cp /home/ubuntu/cht/upgrade-service/.env /home/ubuntu/cht/backup/
-```
-
-###  Backup all CouchDB files
-
-Copy the `couchdb` directory, and all sub-directories:  
+Copy the `.env` and CouchDB files to the newly created directory:  
 
 ```shell
-cp -r /home/ubuntu/cht/couchdb /home/ubuntu/cht/backup/
+cp --archive /home/ubuntu/cht/upgrade-service/.env /home/ubuntu/cht/backup/
+cp --archive /home/ubuntu/cht/couchdb /home/ubuntu/cht/backup/
 ```
 
 ### Verify `.env`
 
-A critical part of a backup is verifying both that the backup was made to the destination, but also that a restore works.  See below for restore, but to verify files were copied we can first check the `.env` files are identical with `md5sum`:
+A critical part of a backup is verifying both that the backup was made to the destination, but also that a restore works.  See [below for restore](#restore), but to verify files were copied we can first check the `.env` files are identical with `md5sum`:
 
 ```shell
 md5sum /home/ubuntu/cht/upgrade-service/.env /home/ubuntu/cht/backup/.env
@@ -69,7 +62,7 @@ d0f3db77002732fafded733e4b4f85f0  /home/ubuntu/cht/backup/.env
 
 ### Verify CouchDB
 
-Check that the file count and directory sizes of `couchdb` directories matches as well:
+Check that the file count and directory sizes of `couchdb` directories matches as well by running these 4 lines:
 
 ```shell
 echo "CouchDB Prod";du -h -d1 /home/ubuntu/cht/couchdb
@@ -79,7 +72,7 @@ echo "CouchDB Prod";ls -R /home/ubuntu/cht/backup/couchdb |wc -l
 echo "CouchDB Backup";ls -R /home/ubuntu/cht/couchdb |wc -l
 ```
 
-Running this should show a similar output to below:
+Running the lines should show a similar output to below. Be sure that `Prod` and `Backup` sections exactly match:
 
 ```shell
 CouchDB Prod
@@ -104,9 +97,11 @@ CouchDB Backup
 
 ## Automated backup
 
-The above manual process is good for a one off backup done by hand.  For ongoing backups, automation that runs regularly is key for success.  Humans often forget to run tasks like backup, where as computers will never forget. This guide will be using `borg` [software](https://borgbackup.readthedocs.io/en/stable/quickstart.html), but administrators should use the software they're most familiar with.
+Manual backups are good a quick one off.  For ongoing backups, automation that runs regularly is key for success.  Humans often forget to run tasks like backup but computers will never forget. This guide uses `borg` [software](https://borgbackup.readthedocs.io/en/stable/quickstart.html), but administrators should use the backup software they're most familiar with.
 
-This example assumes a server called `backup.server` exists with a `borg` user on it. Backing up to a remote server means that if your production server gets entirely deleted, your backups are safe.
+This example assumes a server called `backup.server` exists with a `borg` user on it. Additionally, `borg` should be installed on both the CHT server and the backup server. 
+
+Backing up to a remote server means that if your production server gets entirely deleted, your backups are safe.
 
 {{% steps %}}
 
@@ -132,7 +127,8 @@ backup-server
 On your CHT server, create a new repository `cht` on the `backup.server` server.  Be sure to replace `PASSWORD` with your real password here and all subsequent calls:
 
 ```shell
-BORG_PASSPHRASE='PASSWORD' borg init --encryption repokey-blake2 borg@backup.server:cht
+BORG_PASSPHRASE='PASSWORD' borg init --encryption \
+  repokey-blake2 borg@backup.server:cht
 ```
 
 ### Manually run `borg`
@@ -148,7 +144,7 @@ BORG_PASSPHRASE='PASSWORD' borg create borg@backup.server:cht::$(date "+%y-%m-%d
 On your backup server, verify the manually run backup was successful:
 
 ```shell
-BORG_PASSPHRASE='PASSWORD' borg list /home/borg/cht                                     
+BORG_PASSPHRASE='PASSWORD' borg list /home/borg/cht
 ```                                                                           
 
 This will show the backup you just ran:
@@ -203,10 +199,12 @@ Wait 24 hours.  On the backup server, when you call `borg list...` you should se
 
 ### Optional 1: Prune backups
 
-With the current set up, backups will grow forever in size eventually filling the disk of your backup server.  To prune these so the don't do this, you can set up a cronjob on the backup server to run once per day. This call will keep the past 10 days, keep 4 end of weeks and 1 monthly:
+With the current set up, backups will grow forever in size eventually filling the disk of your backup server.  To avoid this, you can set up a cronjob on the backup server to run once per day. This call will keep the past 10 days, keep 4 end of weeks and 1 monthly:
 
 ```shell
-BORG_PASSPHRASE='PASSWORD' borg prune  --list --keep-within=10d --keep-weekly=4 --keep-monthly=-1 /home/borg/cht
+BORG_PASSPHRASE='PASSWORD' borg prune  \
+  --list --keep-within=10d --keep-weekly=4 \
+  --keep-monthly=-1 /home/borg/cht
 ```
 
 See the [prune docs](https://borgbackup.readthedocs.io/en/master/usage/prune.html) for more information
@@ -215,23 +213,98 @@ See the [prune docs](https://borgbackup.readthedocs.io/en/master/usage/prune.htm
 
 As configured above, an attacker who gained access to your production CHT server, could delete your productoin data and then use `borg` to remotely delete all your backups.  
 
-To prevent this, on your backup server, edit the `/home/borg/.ssh/authorized_keys` file to set a [forced command](https://stackoverflow.com/questions/12346769/ssh-forced-command-parameters).  Prepend this before the SSH Key for your `borg` user:
+To prevent this, on your backup server, edit the `/home/borg/.ssh/authorized_keys` file to set a [forced command](https://stackoverflow.com/questions/12346769/ssh-forced-command-parameters).  Prepend this before the SSH Key for your `borg` user. Note that `ssh-ed25519 AAA...` is the truncated SSH key, be sure to leave the entire SSH key in place:
 
 ```shell
-command="borg serve --append-only --restrict-to-path /home/borg/cht",no-pty,no-agent-forwarding,no-port-forwarding,no-X11-forwarding,no-user-rc  ssh-ed25519 AAA...
+command="borg serve --append-only --restrict-to-path /home/borg/cht/",no-pty,no-agent-forwarding,no-port-forwarding,no-X11-forwarding,no-user-rc ssh-ed25519 AAA...
 ```
 
 {{% /steps %}}
 
 ## Restore
 
-TK
+The restore process involves setting up the CHT, restoring the files from backup, moving the files into position and restarting the CHT.
 
 
 {{% steps %}}
 
-### Step 1
+### Find correct backup
 
-TK
+{{< tabs items="Borg, Manual" >}}
+
+{{< tab >}}
+For users of `borg`, list your backups and find the one you want to use:
+
+```shell
+BORG_PASSPHRASE='PASSWORD' borg list /home/borg/cht
+```
+
+The left column is the backup name and right column is the date and hash of the backup.  In this case, we'll use `25-10-21_11:15:24`
+
+```shell
+25-10-20_15:21:04       Mon, 2025-10-20 22:21:05 [a7698bb7275e3e947234e3d25c3b2084c14b5fd4dd5313f6bc1fef38ecbbca41]
+25-10-21_15:21:56       Tue, 2025-10-21 15:21:56 [26f1f9af11c11027f828f6eab30061e01fb7e69e1cafb3e2eee71f3260546b53]
+25-10-22_01:15:04       Wed, 2025-10-22 01:15:04 [b9e083d0175ea0253644359508c3df1066d49c0e3ad44d97009aac0ce9808b37]
+```
+{{< /tab >}}
+{{< tab >}}
+Manually run backups will use `/home/ubuntu/cht/backup/` as the location of the backup.
+{{< /tab >}}
+{{< /tabs >}}
+
+### Restore to staging
+
+{{< tabs items="Borg, Manual" >}}
+
+{{< tab >}}
+For users of `borg`, restore with this command.  Be sure to replace the name of your repository as needed:
+
+```shell
+mkdir /home/ubuntu/cht/restore
+cd /home/ubuntu/cht/restore
+BORG_PASSPHRASE='PASSWORD' borg extract \
+    --list \
+    borg@backup.server:cht::25-10-21_11:15:24
+mv home/ubuntu/cht/couchdb . 
+mv home/ubuntu/cht/upgrade-service/.env 
+rm -r home
+```
+{{< /tab >}}
+{{< tab >}}
+Manually run backups will use the copy command to copy the files from the `backup` to the `restore` directories:
+
+```shell
+mkdir /home/ubuntu/cht/restore
+cd /home/ubuntu/cht/restore
+cp --archive /home/ubuntu/cht/backup/couchdb /home/ubuntu/cht/backup/.env .
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+Once the files are restored, manually inspect them to ensure they're correct and ready to be put into production
+
+### Stop CHT, Restore and start
+
+Stop all the containers:
+
+```shell
+cd /home/ubuntu/cht/compose
+docker compose  -f cht-core.yml -f cht-couchdb.yml --env-file ../upgrade-service/.env -p cht stop
+```
+
+Copy the staged files into place:
+
+```shell
+cd /home/ubuntu/cht/restore
+cp --archive .env /home/ubuntu/cht/upgrade-service/.env
+sudo cp --archive couchdb/* /home/ubuntu/cht/couchdb/.
+```
+
+Start up the CHT:
+
+```shell
+cd /home/ubuntu/cht/upgrade-service
+docker compose restart
+```
 
 {{% /steps %}}


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Update the [backup docs](https://docs.communityhealthtoolkit.org/hosting/cht/docker/backups/) to be current and more streamlined, closest to happy path. This is an opinionated, literal guide which follows the path of a manual backup, automated backups using `borg` [software](https://borgbackup.readthedocs.io/en/stable/quickstart.html), and a restore process.  The idea is to show the user two paths which they can choose to follow or make a well informed decision to follow their own third path.

closes #1834 

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

