### PR TITLE
chore(na): Bump slack action to v2

### DIFF
--- a/.github/workflows/cron-check-links.yml
+++ b/.github/workflows/cron-check-links.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Report errors to Slack, if any
         if: ${{ github.ref == 'refs/heads/main' && failure() }}
-        uses: rtCamp/action-slack-notify@v2.0.2
+        uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: '${{ secrets.SLACK_WEB_HOOK }}'
           SLACK_CHANNEL: '#cht-doc-site'


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

There was an error on the last link checker CI [attempt](https://github.com/medic/cht-docs/actions/runs/18646523476/job/53154889997):

```
Unable to find image 'rtcamp/action-slack-notify:v2.0.2' locally
docker: Error response from daemon: Head "https://registry-1.docker.io/v2/rtcamp/action-slack-notify/manifests/v2.0.2": received unexpected HTTP status: 503 Service Unavailable
```

We're using `2.0.2`, but `2.3.3` is latest, so let's more loosely pin to get the upgrade.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

