### PR TITLE
feat: disable SONAR rule that prevents `forEach`

### DIFF
--- a/content/en/community/contributing/code/static-analysis.md
+++ b/content/en/community/contributing/code/static-analysis.md
@@ -195,6 +195,8 @@ JavaScript:
    - Disabled
       - [`S2699`](https://rules.sonarsource.com/javascript/RSPEC-2699/) - Tests should include assertions
          - Disabled due of rigidity of the rule when detecting `expect` imports and calls to imported functions that have assertions
+      - [`S7728`](https://rules.sonarsource.com/javascript/RSPEC-7728/) - Use "for...of" loops instead of "forEach" method calls
+          - Disabled beacuse the readability benefits of `forEach` typically outweigh the downsides (especially when chaining with `map` and `filter`)
 
 Python:
 
@@ -213,3 +215,6 @@ TypeScript:
          - `threshold` 7 -> 4
       - [`S3776`](https://rules.sonarsource.com/javascript/RSPEC-3776/) - Cognitive Complexity of functions should not be too high
          - `threshold` 15 -> 5
+   - Disabled
+       - [`S7728`](https://rules.sonarsource.com/javascript/RSPEC-7728/) - Use "for...of" loops instead of "forEach" method calls
+           - Disabled beacuse the readability benefits of `forEach` typically outweigh the downsides (especially when chaining with `map` and `filter`)


### PR DESCRIPTION
# Description

SONAR recently added [a new rule](https://sonarcloud.io/organizations/medic/rules?open=javascript%3AS7728&rule_key=javascript%3AS7728) that you should use `for...of` instead of `forEach`.  See the link for more details, but TLDR:

Using forEach instead of for…​of can lead to:

1. Performance degradation, especially with large arrays due to function call overhead
2. Limited control flow capabilities, preventing early exits and iteration skipping
3. Type safety issues in TypeScript where type narrowing is lost across function boundaries
4. Reduced code maintainability due to less intuitive syntax for simple iterations

Here are my responses to each:

1. If Javascript function call overhead is a concern, you should be using a real programming language and not Javascript. (But seriously, this feels like excessive premature optimization.)
2. This is a feature, not a bug.  If you want/need more control flow, then by all means use `for...each`, but when I see a `forEach` I know it will run that function _for every entry_.
3. This is not a problem if you properly define the parameter types on the function inside the `forEach`.
4. This is just a subjective opinion.  If I wanted to read a whole for...each-block I would have typed it...

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

