### PR TITLE
chore(na): fix 404 link for forEach loop Sonar rule

### DIFF
--- a/content/en/community/contributing/code/static-analysis.md
+++ b/content/en/community/contributing/code/static-analysis.md
@@ -195,7 +195,7 @@ JavaScript:
    - Disabled
       - [`S2699`](https://rules.sonarsource.com/javascript/RSPEC-2699/) - Tests should include assertions
          - Disabled due of rigidity of the rule when detecting `expect` imports and calls to imported functions that have assertions
-      - [`S7728`](https://rules.sonarsource.com/javascript/RSPEC-7728/) - Use "for...of" loops instead of "forEach" method calls
+      - [`S7728`](https://github.com/SonarSource/rspec/blob/master/rules/S7728/javascript/rule.adoc) - Use "for...of" loops instead of "forEach" method calls
           - Disabled beacuse the readability benefits of `forEach` typically outweigh the downsides (especially when chaining with `map` and `filter`)
 
 Python:


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

per most recent [link checker](https://github.com/medic/cht-docs/actions/runs/18834449342/job/53732156318) run, the link to `https://rules.sonarsource.com/javascript/RSPEC-7728/` is now 404 .  Why? I don't know. I found the content [elsewhere](https://github.com/SonarSource/rspec/blob/master/rules/S7728/javascript/rule.adoc) and am deep linking to that :shrug: 

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

