### PR TITLE
chore: delete 'Getting Help' section from migration guide

### DIFF
--- a/content/en/hosting/cht/migration/helm-charts-4x-to-5x-migration.md
+++ b/content/en/hosting/cht/migration/helm-charts-4x-to-5x-migration.md
@@ -129,11 +129,4 @@ Before starting be sure you have a `git clone` of the [CHT Core repository](http
 | Storage Class | `local-storage` | `local-path` | K3s-K3d | Minor |
 | Structure | Flat config | Nested couchdb configuration | All | Medium |
 
-## Getting Help
-
-If you encounter issues during migration:
-
-1. Check the [CHT Documentation](https://docs.communityhealthtoolkit.org/)
-2. Review the [CHT Forum](https://forum.communityhealthtoolkit.org/)
-3. Open an issue in the [CHT Core Repository](https://github.com/medic/cht-core/issues)
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Remove the 'Getting Help' section.

I found this guide when reviewing https://github.com/medic/cht-docs/pull/1953 and I suggest we remove the getting help section as: 1) it links to the docs site itself, 2) it applies to every page on the docs site. Let's keep the pages as concise as possible! 

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

