### PR TITLE
chore: separate SSO overview in a different page for extra clarity

### DIFF
--- a/content/en/hosting/SSO/_index.md
+++ b/content/en/hosting/SSO/_index.md
@@ -3,48 +3,14 @@ title: Single Sign-On
 linkTitle: SSO
 weight: 200
 description: Setting up Single Sign On with the CHT
-relatedContent: >
-  building/login/#single-sign-on-oidc-login
-  building/reference/api/#login-by-oidc
-  building/reference/app-settings/oidc_provider
 ---
 
 {{< callout >}}
 Introduced in 4.20.0. This feature is only compatible with cht-android version `v1.5.2` or greater.
 {{< /callout >}}
 
-## Overview
-
-The CHT supports Single Sign-On (SSO) via integration with an external authentication server. Users connecting to a CHT instance authenticate with their SSO credentials instead of needing a CHT-specific username and password.
- 
-SSO authentication is implemented with the industry standard [OpenID Connect](https://openid.net/) (OIDC) protocol. Any OIDC-compliant authentication server can be integrated with the CHT. For example:
-
-- [Keycloak](https://www.keycloak.org/) - Free and open-source, self-hostable identity and access management server
-- [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/fundamentals/what-is-entra) - Paid, cloud-based identity and access management service.
-
-![sso-login-flow.svg](sso-login-flow.svg)
-
-## Quick Start
-
-1. Add a new client to your OIDC Provider with the redirect URL of `https://<CHT_URL>/medic/login/oidc`. You will need your client id, client secret, and the discovery URL of your OIDC Provider for the next steps. Be sure to replace `CHT_URL` with your real URL.
-2. Add the Client App ID (`APP_ID`), OIDC Provider discovery URL (`WELL_KNOWN_OIDC_URL`) and CHT URL (`CHT_URL`) to your [app_settings.json](/building/reference/app-settings/oidc_provider) using [CHT Conf](/technical-overview/architecture/cht-conf). Be sure to replace `APP_ID`, `WELL_KNOWN_OIDC_URL` and `CHT_URL` with your real URLs:
-
-    ```json
-    "oidc_provider": {
-      "client_id": "<APP_ID>",
-      "discovery_url": "https://<WELL_KNOWN_OIDC_URL>"
-    },
-    "app_url": "https://<CHT_URL>/"
-    ```
-3. Upload the secret from step 1 to the CHT. Be sure to replace `CHT_URL` , `USER`,  `PASSWORD` and `SECRET` with the correct values: `curl -X PUT https://<USER>:<PASSWORD>@<CHT_URL>/api/v1/credentials/oidc:client-secret -H "Content-Type: text/plain" --data "<SECRET>"`
-4. Before logging into the CHT, each SSO user must have a CHT user [provisioned with an "SSO Email Address"](/building/reference/api/#login-by-oidc) that matches the email address configured for the user with the OIDC Provider.
-5. Use the "Login with SSO" button on the CHT login page.
-
-## Detailed guides 
-
-For more detailed guides and requirements, see the following documents:
-
 {{< cards >}}
+  {{< card link="overview" title="Quick Start" subtitle="Get started with SSO in the CHT" icon="lock-closed" >}}
   {{< card link="keycloak" title="KeyCloak" subtitle="Authenticating with KeyCloak" icon="key" >}}
   {{< card link="entra" title="Microsoft Entra" subtitle="Authenticating with Entra" icon="lock-open" >}}
   {{< card link="technical" title="Technical Reference" subtitle="Sequence diagrams and more" icon="terminal" >}}

--- a/content/en/hosting/SSO/overview.md
+++ b/content/en/hosting/SSO/overview.md
@@ -1,0 +1,51 @@
+---
+title: Single Sign-On
+linkTitle: Quick Start
+weight: 1
+description: Getting Started with Single Sign-On and the CHT
+relatedContent: >
+  building/login/#single-sign-on-oidc-login
+  building/reference/api/#login-by-oidc
+  building/reference/app-settings/oidc_provider
+---
+
+{{< callout >}}
+Introduced in 4.20.0. This feature is only compatible with cht-android version `v1.5.2` or greater.
+{{< /callout >}}
+
+## Overview
+
+The CHT supports Single Sign-On (SSO) via integration with an external authentication server. Users connecting to a CHT instance authenticate with their SSO credentials instead of needing a CHT-specific username and password.
+ 
+SSO authentication is implemented with the industry standard [OpenID Connect](https://openid.net/) (OIDC) protocol. Any OIDC-compliant authentication server can be integrated with the CHT. For example:
+
+- [Keycloak](https://www.keycloak.org/) - Free and open-source, self-hostable identity and access management server
+- [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/fundamentals/what-is-entra) - Paid, cloud-based identity and access management service.
+
+![sso-login-flow.svg](sso-login-flow.svg)
+
+## Quick Start
+
+1. Add a new client to your OIDC Provider with the redirect URL of `https://<CHT_URL>/medic/login/oidc`. You will need your client id, client secret, and the discovery URL of your OIDC Provider for the next steps. Be sure to replace `CHT_URL` with your real URL.
+2. Add the Client App ID (`APP_ID`), OIDC Provider discovery URL (`WELL_KNOWN_OIDC_URL`) and CHT URL (`CHT_URL`) to your [app_settings.json](/building/reference/app-settings/oidc_provider) using [CHT Conf](/technical-overview/architecture/cht-conf). Be sure to replace `APP_ID`, `WELL_KNOWN_OIDC_URL` and `CHT_URL` with your real URLs:
+
+    ```json
+    "oidc_provider": {
+      "client_id": "<APP_ID>",
+      "discovery_url": "https://<WELL_KNOWN_OIDC_URL>"
+    },
+    "app_url": "https://<CHT_URL>/"
+    ```
+3. Upload the secret from step 1 to the CHT. Be sure to replace `CHT_URL` , `USER`,  `PASSWORD` and `SECRET` with the correct values: `curl -X PUT https://<USER>:<PASSWORD>@<CHT_URL>/api/v1/credentials/oidc:client-secret -H "Content-Type: text/plain" --data "<SECRET>"`
+4. Before logging into the CHT, each SSO user must have a CHT user [provisioned with an "SSO Email Address"](/building/reference/api/#login-by-oidc) that matches the email address configured for the user with the OIDC Provider.
+5. Use the "Login with SSO" button on the CHT login page.
+
+## Detailed Guides 
+
+For more detailed guides and requirements, see the following documents:
+
+{{< cards >}}
+  {{< card link="keycloak" title="KeyCloak" icon="key" >}}
+  {{< card link="entra" title="Microsoft Entra" icon="lock-open" >}}
+  {{< card link="technical" title="Technical Reference" icon="terminal" >}}
+{{< /cards >}}

--- a/content/en/hosting/SSO/technical.md
+++ b/content/en/hosting/SSO/technical.md
@@ -1,5 +1,5 @@
 ---
-title: SSO technical reference
+title: SSO Technical Reference
 linkTitle: Technical
 weight: 400
 ---
@@ -8,7 +8,7 @@ weight: 400
 Introduced in 4.20.0. This feature is only compatible with cht-android version `v1.5.2` or greater.
 {{< /callout >}}
 
-CHT `4.20.0` introduced the single sign on (SSO) feature allowing deployments to use the industry standard [OpenID Connect](https://openid.net/) (OIDC) protocol to authenticate users.  Below are some key points on the SSO functionality in the CHT. See the [technical design document](https://docs.google.com/document/d/1LUn1ZRetAmYE04CtdcTmp-bEBvl37AZ0CvFXZChXqfU/edit?tab=t.0) for all the details.
+Single Sign-On (SSO) feature allows deployments to use the industry standard [OpenID Connect](https://openid.net/) (OIDC) protocol to authenticate users. Below are some key points on the SSO functionality in the CHT. See the [technical design document](https://docs.google.com/document/d/1LUn1ZRetAmYE04CtdcTmp-bEBvl37AZ0CvFXZChXqfU/edit?tab=t.0) for more details.
 
 ## Setup 
 
@@ -26,7 +26,7 @@ A user with the `oidc_username` property is only allowed to log in with SSO. Any
 
 To convert an SSO user in the CHT back to a normal CHT user (with username/password authentication), simply remove the user's `oidc_username` (by deleting the value from the "SSO Email Address" field). A new password must then be set for the user. All the user's existing sessions will be invalidated and the user must log in again (this time by using their CHT username/password).
 
-## CHT User session 
+## CHT User Session 
 
 Once an SSO user has successfully authenticated with the CHT (by completing the OIDC flow), their browser receives a valid Couch session cookie (equivalent to the session cookies provided to normal CHT users). For all subsequent operations, the CHT does not distinguish between SSO and non-SSO users since both types of users are authenticating with the same type of session cookie.
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

SSO Overview content bloats the SSO section homepage. I suggest separating the content into its own page for extra clarity and consistency across sections. 

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

