### PR TITLE
chore: change API to REST API in the left navigation bar

### DIFF
--- a/content/en/building/reference/api.md
+++ b/content/en/building/reference/api.md
@@ -1,6 +1,6 @@
 ---
-title: "API to interact with CHT Applications"
-linkTitle: "API"
+title: "REST API to interact with CHT Applications"
+linkTitle: "REST API"
 weight: 1
 description: >
   RESTful Application Programming Interfaces for integrating with CHT applications
@@ -14,7 +14,7 @@ aliases:
 }
 </style>
 
-This page covers the endpoints to use when integrating with the CHT server. If there isn't an endpoint that provides the function or data you need, direct access to the database is possible via the [CouchDB API](https://docs.couchdb.org/en/stable/api/index.html). Access to the [PostgreSQL database](/technical-overview/data/analytics/data-flows-for-analytics) may also prove useful for data analysis. If additional endpoints would be helpful, make suggestions via a [GitHub issue](https://github.com/medic/cht-core/issues/new/choose).
+This page covers the REST endpoints to use when integrating with the CHT server. If there isn't an endpoint that provides the function or data you need, direct access to the database is possible via the [CouchDB API](https://docs.couchdb.org/en/stable/api/index.html). Access to the [PostgreSQL database](/technical-overview/data/analytics/data-flows-for-analytics) may also prove useful for data analysis. If additional endpoints would be helpful, make suggestions via a [GitHub issue](https://github.com/medic/cht-core/issues/new/choose).
 
 {{< toc >}}
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

On the left hand side of the navigation bar in `Build -> Reference` there are `API` and `CHT API`. To provide more clarity that API mean REST API these changes were made.

Before:

<img width="1273" height="680" alt="Screenshot_20251106_103026" src="https://github.com/user-attachments/assets/2351c654-0ac8-48c7-9141-8cd5c206ebbf" />

After:

<img width="1672" height="776" alt="image" src="https://github.com/user-attachments/assets/69c6491c-e705-4050-aee8-2b74242b1a87" />


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

