### PR TITLE
chore(na): nginx restart in certbot cronjob

### DIFF
--- a/content/en/hosting/cht/docker/adding-tls-certificates.md
+++ b/content/en/hosting/cht/docker/adding-tls-certificates.md
@@ -121,9 +121,9 @@ Assuming your CHT instance is **already running with the default self-signed cer
     ```shell
     docker exec -it cht_nginx_1 nginx -s reload
     ```
-7. Attempt to renew your certificates once a week by adding this cronjob via `crontab -e`.  Certbot will only renew them as needed:
+7. Attempt to renew your certificates once a week by adding this cronjob via `crontab -e`.  Certbot will only renew them as needed.  Per prior step, be sure to check that the name of your container is `cht_nginx_1` from two steps ago:
    ```shell
-   0 0 * * 0 cd /home/ubuntu/cht/certbot&&docker compose up
+   0 0 * * 0 cd /home/ubuntu/cht/certbot && docker compose up && docker exec -it cht_nginx_1 nginx -s reload
    ```
 
 ## Troubleshooting


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Our [TLS docs](https://docs.communityhealthtoolkit.org/hosting/cht/docker/adding-tls-certificates/) have certbot attempt to renew the cert, but it does not restart `nginx`.  This means new certs won't get loaded.

This PR adds an `nginx` reload call to the cronjob.

this issue was discovered in a Medic production instance (see private [ticket](https://github.com/medic/medic-infrastructure/issues/1312))

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

