### PR TITLE
fix(na): fix rules.sonarsource.com links with archive.org

### DIFF
--- a/content/en/community/contributing/code/static-analysis.md
+++ b/content/en/community/contributing/code/static-analysis.md
@@ -148,7 +148,7 @@ The quality profiles are the lists of rules that will be applied for the various
 
 ###### Modifying rule parameters
 
-To modify a rule parameter (e.g. change the allowed level of complexity for a function [according to `javascript:S3776`](https://rules.sonarsource.com/javascript/RSPEC-3776/)):
+To modify a rule parameter (e.g. change the allowed level of complexity for a function [according to `javascript:S3776`](https://web.archive.org/web/20250720035236/https://rules.sonarsource.com/javascript/RSPEC-3776/)):
 
 1. Open a cht-docs PR to record your rule modification in the list below. This allows us to track the history of rule changes and record for posterity the discussions about them.
 1. If not already using a custom quality profile, use the SonarCloud UI to create one that _extends_ the `Sonar Way` profile.
@@ -179,41 +179,41 @@ Java:
 
 - **CHT Way**  _(default)_ extends **Sonar Way**
   - Modified:
-    - [`S107`](https://rules.sonarsource.com/javascript/RSPEC-107/) - Functions should not have too many parameters
+    - [`S107`](https://web.archive.org/web/20251113054741/https://rules.sonarsource.com/javascript/RSPEC-107/) - Functions should not have too many parameters
       - `threshold` 7 -> 4
-    - [`S3776`](https://rules.sonarsource.com/javascript/RSPEC-3776/) - Cognitive Complexity of functions should not be too high
+    - [`S3776`](https://web.archive.org/web/20250720035236/https://rules.sonarsource.com/javascript/RSPEC-3776/) - Cognitive Complexity of functions should not be too high
       - `threshold` 15 -> 5
 
 JavaScript:
 
 - **CHT Way**  _(default)_ extends **Sonar Way**
    - Modified:
-      - [`S107`](https://rules.sonarsource.com/javascript/RSPEC-107/) - Functions should not have too many parameters
+      - [`S107`](https://web.archive.org/web/20251113054741/https://rules.sonarsource.com/javascript/RSPEC-107/) - Functions should not have too many parameters
          - `threshold` 7 -> 4
-      - [`S3776`](https://rules.sonarsource.com/javascript/RSPEC-3776/) - Cognitive Complexity of functions should not be too high
+      - [`S3776`](https://web.archive.org/web/20250720035236/https://rules.sonarsource.com/javascript/RSPEC-3776/) - Cognitive Complexity of functions should not be too high
          - `threshold` 15 -> 5
    - Disabled
-      - [`S2699`](https://rules.sonarsource.com/javascript/RSPEC-2699/) - Tests should include assertions
+      - [`S2699`](https://web.archive.org/web/20251017003858/https://rules.sonarsource.com/javascript/RSPEC-2699/) - Tests should include assertions
          - Disabled due of rigidity of the rule when detecting `expect` imports and calls to imported functions that have assertions
-      - [`S7728`](https://github.com/SonarSource/rspec/blob/master/rules/S7728/javascript/rule.adoc) - Use "for...of" loops instead of "forEach" method calls
-          - Disabled beacuse the readability benefits of `forEach` typically outweigh the downsides (especially when chaining with `map` and `filter`)
+      - [`S7728`](https://community.sonarsource.com/t/use-for-of-instead-of-foreach-typescript-s7728/151980/5) - Use "for...of" loops instead of "forEach" method calls
+          - Disabled because the readability benefits of `forEach` typically outweigh the downsides (especially when chaining with `map` and `filter`)
 
 Python:
 
 - **CHT Way**  _(default)_ extends **Sonar Way**
    - Modified:
-      - [`S107`](https://rules.sonarsource.com/javascript/RSPEC-107/) - Functions should not have too many parameters
+      - [`S107`](https://web.archive.org/web/20251113054741/https://rules.sonarsource.com/javascript/RSPEC-107/) - Functions should not have too many parameters
          - `threshold` 7 -> 4
-      - [`S3776`](https://rules.sonarsource.com/javascript/RSPEC-3776/) - Cognitive Complexity of functions should not be too high
+      - [`S3776`](https://web.archive.org/web/20250720035236/https://rules.sonarsource.com/javascript/RSPEC-3776/) - Cognitive Complexity of functions should not be too high
          - `threshold` 15 -> 5
 
 TypeScript:
 
 - **CHT Way**  _(default)_ extends **Sonar Way**
    - Modified:
-      - [`S107`](https://rules.sonarsource.com/javascript/RSPEC-107/) - Functions should not have too many parameters
+      - [`S107`](https://web.archive.org/web/20251113054741/https://rules.sonarsource.com/javascript/RSPEC-107/) - Functions should not have too many parameters
          - `threshold` 7 -> 4
-      - [`S3776`](https://rules.sonarsource.com/javascript/RSPEC-3776/) - Cognitive Complexity of functions should not be too high
+      - [`S3776`](https://web.archive.org/web/20250720035236/https://rules.sonarsource.com/javascript/RSPEC-3776/) - Cognitive Complexity of functions should not be too high
          - `threshold` 15 -> 5
    - Disabled
        - [`S7728`](https://github.com/SonarSource/rspec/blob/master/rules/S7728/javascript/rule.adoc) - Use "for...of" loops instead of "forEach" method calls


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Fix 404s according to [most recent](https://github.com/medic/cht-docs/commit/59770fc67f6c0ee2c8be0947ad172438fafbbfbe/checks) link checker run:

```
http://localhost:1313/community/contributing/code/static-analysis/
	404	https://github.com/SonarSource/rspec/blob/master/rules/S7728/javascript/rule.adoc
	404	https://rules.sonarsource.com/javascript/RSPEC-107/
	404	https://rules.sonarsource.com/javascript/RSPEC-2699/
	404	https://rules.sonarsource.com/javascript/RSPEC-3776/
```

I gave up after searching and searching for a new location for either github.com/SonarSource/rspec or rules.sonarsource.com/javascript both which are 404ing with seemingly no replacement :shrug: ?  Open to a reviewer finding a better source!


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

