### PR TITLE
Remove "when to wait" in release notes

### DIFF
--- a/content/en/community/contributing/code/releasing/_index.md
+++ b/content/en/community/contributing/code/releasing/_index.md
@@ -45,19 +45,6 @@ Given a version number `MAJOR.MINOR.PATCH`, increment the:
 > [!IMPORTANT]  
 > You can find the versions currently supported, dependencies, and release notes for the CHT Core [on the Releases page]({{% ref "releases/" %}}). 
 
-### When to wait to release
-
-In general, release managers should not feel they have to wait to do a release. The moment the release manager feels the release is ready, they should release it. This may even be with just one ticket!
-
-There are two scenarios where a release manager should wait before doing the release:
-
-1. There is a bug found in `master` that did not exist in the previous release.  This should be fixed before the release.
-2. There is a high priority bug found in an existing release that it is estimated to be fixed in less than 5 days. The way to determine if a bug is high priority is if a service pack release is needed to fix it later. If so then it makes sense to wait for the fix to save the effort of having to do two releases in quick succession. If it's going to take longer than 5 days then it's worth the additional effort of releasing a service pack. After 5 days if the fix isn't merged, then continue with the release regardless.
-
-The reason to have these rules while waiting, is so that all contributors know what they are and the release manager never needs to ask "should we wait?" - they'll know already!
-
-While waiting the release manager should use the time effectively by doing as many release steps as possible including writing release notes, preparing the release branch, etc so that the release can be finalized as quickly as possible once the fixes are made.
-
 ## CHT Conf
 
 Follow the [instructions in the readme](https://github.com/medic/cht-conf/#user-content-releasing).


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Remove "when to wait" in release notes.  Recently Stewardship was realizing that our release cadence has been slower than this and we wanted to make sure folks weren't confused about our process.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

