### PR TITLE
fix(NA): block bare "/" key from triggering Kapa search modal

### DIFF
--- a/layouts/partials/custom/head-end.html
+++ b/layouts/partials/custom/head-end.html
@@ -180,6 +180,11 @@
         e.stopPropagation();
         openKapa(KAPA_MODE.SEARCH);
       }
+      // Block bare "/" from reaching Hextra's search focus handler
+      if (e.key === '/' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
     }, true); // Capture phase to intercept before Hextra
   };
 


### PR DESCRIPTION
# Description

Hextra's built-in "/" keyboard shortcut focuses the search input, which triggers Kapa's focus handler to open the search modal. This fix blocks the bare "/" keypress in the capture phase so only Ctrl+/ opens the Kapa search modal.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.