### PR TITLE
Add dynamic Create Docs Issue link with prefilled page context

### DIFF
--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -18,6 +18,7 @@
       {{ partial "components/feedback.html" . }}
       {{ partial "components/pager.html" . }}
       {{ partial "components/comments.html" . }}
+      {{ partial "custom/docs-issue-link.html" . }}
     </main>
   </article>
 </div>

--- a/layouts/partials/custom/docs-issue-link.html
+++ b/layouts/partials/custom/docs-issue-link.html
@@ -1,0 +1,4 @@
+{{- $issueTitle := urlquery (printf "Improve: %s" .Title) -}}
+{{- $issueBody := urlquery (printf "Page: %s" .Permalink) -}}
+{{- $link := printf "https://github.com/medic/cht-docs/issues/new?title=%s&body=%s" $issueTitle $issueBody -}}
+<a href="{{ $link }}" target="_blank" rel="noreferrer">Create Docs Issue ↗</a>

--- a/layouts/partials/custom/head-end.html
+++ b/layouts/partials/custom/head-end.html
@@ -402,5 +402,6 @@
   } else {
     init();
   }
+
 })();
 </script>


### PR DESCRIPTION
# Description

This PR enhances the "Create Docs Issue" link by pre-filling the GitHub issue form with the current page context.

Fixes #2025 

## Changes

1) Dynamically updates the "Create Docs Issue" link to include.
  - Page title in the issue title
  - Page URL in the issue body

2) Implemented using JavaScript to ensure compatibility with the Hugo theme module setup.

## Why

Previously, the "Create Docs Issue" link opened a blank issue form, requiring users to manually provide context.

This change improves user experience by automatically including the page name and link. It also makes it easier to report documentation issues.

## Screenshots

https://github.com/user-attachments/assets/65e81b32-08a0-4d52-93c7-9d005d756da9

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.