### PR TITLE
chore(na): in muffet, exclude sonarsource, decrease max-connections rate

### DIFF
--- a/.github/scripts/muffet.sh
+++ b/.github/scripts/muffet.sh
@@ -16,8 +16,8 @@
 ./2.11.1.muffet http://localhost:1313 \
   --buffer-size 50000 \
   --timeout 255 \
-  --rate-limit 4 \
-  --max-connections-per-host 8 \
+  --rate-limit 3 \
+  --max-connections-per-host 6 \
   --ignore-fragments \
   --header="User-Agent: Muffet (github.com/raviqqe/muffet) on behalf of CHT Docs (docs.communityhealthtoolkit.org)" \
   --exclude "http[s]*://.*africastalking.com.*" \
@@ -74,6 +74,7 @@
   --exclude "http[s]*://news.ycombinator.com/item?id=1547647" \
   --exclude "http[s]*://pmc.ncbi.nlm.nih.gov/articles/PMC6903365/" \
   --exclude "http[s]*://ruky.me/hacking-cht-user-interface-with-javascript-to-format-content/" \
+  --exclude "http[s]*://www.sonarsource.com/" \
   --exclude "http[s]*://localhost:[3000|8443|5984]+" \
   --exclude "http[s]*://localhost$" \
   --exclude "http[s]*://127.*"


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

We've gotten sonarsource URL [flagged](https://github.com/medic/cht-docs/commit/eeee05fcaae288e9b42cedf0ba58cd4bef93cdc5/checks) more than once as `timeout` and we often get `502`s in link checker, so changing `max-connections-per-host` from `8` to `6` and `rate-limit` from `4` to `3` per muffet [usage info](https://raviqqe.com/muffet/usage/).

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

