### PR TITLE
fix(#8974): remove note about form `end` issue

### DIFF
--- a/content/en/building/forms/app.md
+++ b/content/en/building/forms/app.md
@@ -68,11 +68,11 @@ Since writing raw XML can be tedious, we suggest creating the forms using the [X
 ### Supported XLSForm Meta Fields
 [XLSForm](http://xlsform.org/) has a number of [data type options](https://xlsform.org/en/#metadata) available for meta data collection, of which the following are supported in CHT app forms:
 
-| element | description                                                                                                                                                                                                                                          |
-|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `start` | A timestamp of when the form entry was started, which occurs when the form is fully loaded.                                                                                                                                                          |
-| `end`   | A timestamp of when the form entry ended, which is when the user hits the Submit button. (There is an [active issue](https://github.com/medic/cht-core/issues/8974) filed for this field. Currently it is populated with the same value as `start`.) |
-| `today` | Day on which the form entry was started.                                                                                                                                                                                                             |
+| element | description                                                                                 |
+|---------|---------------------------------------------------------------------------------------------|
+| `start` | A timestamp of when the form entry was started, which occurs when the form is fully loaded. |
+| `end`   | A timestamp of when the form entry ended, which is when the user hits the Submit button.    |
+| `today` | Day on which the form entry was started.                                                    |
 
 ## XPath
 Calculations are achieved within app forms using XPath statements in the "calculate" field of XForms and XLSForms. CHT apps support XPath from the [ODK XForm spec](https://getodk.github.io/xforms-spec), which is based on a subset of [XPath 1.0](https://www.w3.org/TR/1999/REC-xpath-19991116/), and is evaluated by [`openrosa-xpath-evaluator`](https://github.com/enketo/enketo/tree/main/packages/openrosa-xpath-evaluator). The ODK XForm documentation provides useful notes about the available [operators](https://getodk.github.io/xforms-spec/#xpath-operators) and [functions](https://getodk.github.io/xforms-spec/#xpath-functions). Additionally, [CHT specific functions](#cht-xpath-functions) are available for forms in CHT apps.


### PR DESCRIPTION
# Description

cht-core issue: https://github.com/medic/cht-core/issues/8974
cht-core PR: https://github.com/medic/cht-core/pull/10784

There used to be a bug in the cht-core handling of the `end` field in forms.  Now the bug is fixed!

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

