### PR TITLE
feat(#2112): enhance 404 page with branding, search, and helpful links

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,31 @@
+{{ define "main" }}
+<div class='hx:mx-auto hx:flex hextra-max-page-width'>
+  {{ partial "sidebar.html" (dict "context" .) }}
+  <article
+    class="hx:w-full hx:break-words hx:flex hx:min-h-[calc(100vh-var(--navbar-height))] hx:min-w-0 hx:justify-center hx:pb-8 hx:pr-[calc(env(safe-area-inset-right)-1.5rem)]">
+    <main class="hx:w-full hx:min-w-0 hx:max-w-6xl hx:px-6 hx:pt-4 hx:md:px-12">
+
+      <div class="content">
+        <h1 class="hx:text-8xl md:hx:text-9xl hx:font-extrabold hx:tracking-tight">
+          404
+        </h1>
+        <p class="not-prose hx:text-2xl md:hx:text-3xl hx:text-gray-600 dark:hx:text-gray-400 hx:mt-4">
+          The page you are looking for doesn't exist
+        </p>
+        <p>
+          Here are some helpful resources to guide you:
+        </p>
+        <ul>
+          <li><a href="/">Return to the Documentation Home</a></li>
+          <li><a href="/contributing/">Contributing to CHT</a></li>
+          <li><a href="/core/">CHT Core</a></li>
+          <li><a href="/apps/">CHT Applications</a></li>
+        </ul>
+        <p>
+          Use the search bar above to locate the page you are looking for.
+        </p>
+      </div>
+    </main>
+  </article>
+</div>
+{{ end }}

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -9,20 +9,9 @@
         <h1 class="hx:text-8xl md:hx:text-9xl hx:font-extrabold hx:tracking-tight">
           404
         </h1>
-        <p class="not-prose hx:text-2xl md:hx:text-3xl hx:text-gray-600 dark:hx:text-gray-400 hx:mt-4">
-          The page you are looking for doesn't exist
-        </p>
-        <p>
-          Here are some helpful resources to guide you:
-        </p>
-        <ul>
-          <li><a href="/">Return to the Documentation Home</a></li>
-          <li><a href="/contributing/">Contributing to CHT</a></li>
-          <li><a href="/core/">CHT Core</a></li>
-          <li><a href="/apps/">CHT Applications</a></li>
-        </ul>
-        <p>
-          Use the search bar above to locate the page you are looking for.
+	<p> 
+          The page you are looking for doesn't exist. Please use the search bar or the 
+	  navigation menu to locate the page you are looking for.
         </p>
       </div>
     </main>


### PR DESCRIPTION
## Problem
The current 404 page only displays “404 - This page could not be found” without navigation, search, or branding. As a result, users cannot:
- Identify that they are on a CHT documentation page
- Navigate back to relevant content
- Search for the information they need

## Solution
Added a custom `layouts/404.html` page aligned with the existing documentation layout:
- Integrated sidebar navigation and top search bar
- Included CHT branding for consistency
- Added helpful guidance and links for users



<img width="1076" height="700" alt="Screenshot 2026-04-25 at 00 10 13" src="https://github.com/user-attachments/assets/f66093da-ebc9-4231-97cb-ffb8e1543da9" />




Fixes #2112