### PR TITLE
fix(#2198): prevent sidebar-only takeover at tablet widths (768px width) and zoom

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -282,9 +282,3 @@ Fix Resolve conflict between Hextra's 48rem and Tailwind's 768px breakpoints
     transform: none !important; 
   }
 }
-
-@media (max-width: 767.98px) {
-  aside.hextra-sidebar-container:not(.hx\:max-md\:\[transform\:translate3d\(0\,0\,0\)\]) {
-    transform: translate3d(0, -100%, 0) !important;
-  }
-}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -273,10 +273,18 @@ video {
 }
 
 /* -----------------------------------------------
-Fix Close subpixel gap between max-md (767px) and md (768px) breakpoints
+Fix Resolve conflict between Hextra's 48rem and Tailwind's 768px breakpoints
 --------------------------------------------------*/
-@media (min-width: 767.01px) and (max-width: 767.99px) {
-  .hextra-sidebar-container:not(.hx\:max-md\:\[transform\:translate3d\(0\,0\,0\)\]) {
+@media (min-width: 768px) {
+  aside.hextra-sidebar-container {
+    position: sticky !important;
+    width: 16rem !important; 
+    transform: none !important; 
+  }
+}
+
+@media (max-width: 767.98px) {
+  aside.hextra-sidebar-container:not(.hx\:max-md\:\[transform\:translate3d\(0\,0\,0\)\]) {
     transform: translate3d(0, -100%, 0) !important;
   }
 }

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -271,3 +271,32 @@ Fix content too tight around video HTML tags
 video {
     padding-top: 25px;
 }
+
+/* -----------------------------------------------
+Fix prevent sidebar-only takeover around tablet width + zoom 
+--------------------------------------------------*/
+@media (max-width: 1023.98px) {
+  .hextra-sidebar-container {
+    position: fixed;
+    top: var(--navbar-height);
+    left: 0;
+    width: min(20rem, 100vw);
+    height: calc(100vh - var(--navbar-height));
+    z-index: 30;
+    background-color: var(--hx-color-white);
+    transform: translate3d(0, -100%, 0) !important;
+  }
+
+  :where(.dark, .dark *) .hextra-sidebar-container {
+    background-color: var(--hx-color-dark);
+  }
+
+  .hextra-sidebar-container.hx\:max-md\:\[transform\:translate3d\(0\,0\,0\)\] {
+    transform: translate3d(0, 0, 0) !important;
+  }
+
+  article {
+    width: 100%;
+    min-width: 0;
+  }
+}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -273,7 +273,7 @@ video {
 }
 
 /* -----------------------------------------------
-Close subpixel gap between max-md (767px) and md (768px) breakpoints 
+Fix #2198: Close subpixel gap between max-md (767px) and md (768px) breakpoints
 --------------------------------------------------*/
 @media (min-width: 767.01px) and (max-width: 767.99px) {
   .hextra-sidebar-container:not(.hx\:max-md\:\[transform\:translate3d\(0\,0\,0\)\]) {

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -273,7 +273,7 @@ video {
 }
 
 /* -----------------------------------------------
-Fix #2198: Close subpixel gap between max-md (767px) and md (768px) breakpoints
+Fix Close subpixel gap between max-md (767px) and md (768px) breakpoints
 --------------------------------------------------*/
 @media (min-width: 767.01px) and (max-width: 767.99px) {
   .hextra-sidebar-container:not(.hx\:max-md\:\[transform\:translate3d\(0\,0\,0\)\]) {

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -273,30 +273,10 @@ video {
 }
 
 /* -----------------------------------------------
-Fix prevent sidebar-only takeover around tablet width + zoom 
+Close subpixel gap between max-md (767px) and md (768px) breakpoints 
 --------------------------------------------------*/
-@media (max-width: 1023.98px) {
-  .hextra-sidebar-container {
-    position: fixed;
-    top: var(--navbar-height);
-    left: 0;
-    width: min(20rem, 100vw);
-    height: calc(100vh - var(--navbar-height));
-    z-index: 30;
-    background-color: var(--hx-color-white);
+@media (min-width: 767.01px) and (max-width: 767.99px) {
+  .hextra-sidebar-container:not(.hx\:max-md\:\[transform\:translate3d\(0\,0\,0\)\]) {
     transform: translate3d(0, -100%, 0) !important;
-  }
-
-  :where(.dark, .dark *) .hextra-sidebar-container {
-    background-color: var(--hx-color-dark);
-  }
-
-  .hextra-sidebar-container.hx\:max-md\:\[transform\:translate3d\(0\,0\,0\)\] {
-    transform: translate3d(0, 0, 0) !important;
-  }
-
-  article {
-    width: 100%;
-    min-width: 0;
   }
 }


### PR DESCRIPTION
Prevent sidebar-only view at 768px

closes #2198 

# Description

This PR fixes a responsive layout issue where the left sidebar could take over the page around 768px width (especially with browser zoom), making main content hard to access.

### What I changed
- Updated `assets/css/custom.css`.
- Added a tablet/mobile CSS guard for `.hextra-sidebar-container` (`max-width: 1023.98px`).
- Set fixed position and height so it behaves like a proper drawer.
- Ensured main content (`article`) keeps `width: 100%` and `min-width: 0`.

### Result
At 768px, the layout no longer gets stuck in a sidebar-only state.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.


<img width="1470" height="956" alt="Screenshot 2026-04-25 at 1 07 37 AM" src="https://github.com/user-attachments/assets/5f4156b6-b21f-4c28-8b5c-793dd0aced7b" />
