### PR TITLE
chore(na): remove g++ & make, use python3 isntead of 2 for windows

### DIFF
--- a/content/en/community/contributing/code/core/dev-environment.md
+++ b/content/en/community/contributing/code/core/dev-environment.md
@@ -35,7 +35,7 @@ _(Node {{< param nodeVersion >}} is the environment used to run the CHT server i
   {{< tab >}}
 ```shell
   sudo apt update && sudo apt -y dist-upgrade
-  sudo apt -y install xsltproc curl uidmap jq python3 git make g++
+  sudo apt -y install xsltproc curl uidmap jq python3 git
   # Use NVM to install NodeJS:
   export nvm_version=`curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r .name`
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_version/install.sh | $SHELL
@@ -47,7 +47,7 @@ _(Node {{< param nodeVersion >}} is the environment used to run the CHT server i
 ```shell
   # Uses Homebrew: https://brew.sh/
   brew update
-  brew install curl jq pyenv git make node@{{< param nodeVersion >}} gcc
+  brew install curl jq pyenv git make node@{{< param nodeVersion >}}
   # Python no longer included by default in macOS >12.3 
   pyenv install 2.7.18
   pyenv global 2.7.18
@@ -58,7 +58,7 @@ _(Node {{< param nodeVersion >}} is the environment used to run the CHT server i
   {{< tab >}}
 ```shell
   sudo apt update && sudo apt -y dist-upgrade
-  sudo apt -y install xsltproc curl uidmap jq python2 git make g++
+  sudo apt -y install xsltproc curl uidmap jq python3 git
   # Use NVM to install NodeJS:
   export nvm_version=`curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r .name`
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_version/install.sh | $SHELL

--- a/content/en/community/contributing/code/core/dev-environment.md
+++ b/content/en/community/contributing/code/core/dev-environment.md
@@ -35,7 +35,7 @@ _(Node {{< param nodeVersion >}} is the environment used to run the CHT server i
   {{< tab >}}
 ```shell
   sudo apt update && sudo apt -y dist-upgrade
-  sudo apt -y install xsltproc curl uidmap jq python3 git
+  sudo apt -y install xsltproc curl uidmap jq python3 git make
   # Use NVM to install NodeJS:
   export nvm_version=`curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r .name`
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_version/install.sh | $SHELL
@@ -58,7 +58,7 @@ _(Node {{< param nodeVersion >}} is the environment used to run the CHT server i
   {{< tab >}}
 ```shell
   sudo apt update && sudo apt -y dist-upgrade
-  sudo apt -y install xsltproc curl uidmap jq python3 git
+  sudo apt -y install xsltproc curl uidmap jq python3 git make
   # Use NVM to install NodeJS:
   export nvm_version=`curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r .name`
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_version/install.sh | $SHELL


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

When I recently [deprecated the windows page](https://github.com/medic/cht-docs/commit/2b746016349b04efc40ad6d7c9a4484eef4b96d9), I noted we still installed python2 for windows - which isn't right.  Then  I saw we still install `make` and `g++` which I was used to when still installed stuff with `python` and `pip` which we no longer do.  So it should be safe to remove? Counting on my code reviewer to keep me honest

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

