### PR TITLE
feat: add more advanced params to cost calculator

### DIFF
--- a/assets/css/cost-calculator.css
+++ b/assets/css/cost-calculator.css
@@ -116,16 +116,13 @@ html.dark {
     flex-direction: column;
 
     .advanced-inputs-scroll {
-      overflow-y: auto;
+      overflow-y: scroll;
       min-height: 0;
       max-height: 19rem;
       margin-right: -0.75rem;
       padding-right: 0.25rem;
       scrollbar-width: thin;
-      scrollbar-color: transparent transparent;
-      &:hover {
-        scrollbar-color: var(--calc-border) transparent;
-      }
+      scrollbar-color: var(--calc-border) transparent;
     }
 
     > .calc-divider {

--- a/assets/js/cost-calculator.js
+++ b/assets/js/cost-calculator.js
@@ -6,7 +6,6 @@ const DEFAULTS = {
   USERS_PER_CPU: 288,
   RAM_PER_CPU: 2,
   COST_PER_CPU_MONTH: 20.85,
-  DOCS_PER_POP_WORKFLOW_YEAR: 1,
   ROOT_VOLUME_GB: 50
 };
 
@@ -18,6 +17,7 @@ const UI_CONSTANTS = {
   USERS: { value: 1000, min: 10, max: 15000, step: 10 },
   DEPLOYMENT_AGE: { value: 1, min: 1, max: 10 },
   DB_OVERPROVISION: { value: 5, min: 1, max: 10 },
+  DOCS_PER_WORKFLOW: { value: 1, min: 1, max: 100 },
 };
 
 const formatCurrency = (amount, opts = {}) => amount.toLocaleString(navigator.language, {
@@ -66,9 +66,13 @@ const calculateMetrics = (els) => {
     1,
     Number.parseInt(els.dbOverprovision?.value || UI_CONSTANTS.DB_OVERPROVISION.value)
   );
+  const docsPerWorkflowYear = Math.max(
+    1,
+    Number.parseInt(els.docsPerWorkflow?.value || UI_CONSTANTS.DOCS_PER_WORKFLOW.value)
+  );
   const placeCount = Math.floor(populationCount * DEFAULTS.PLACES_PER_POP);
   const contactCount = userCount + populationCount + placeCount;
-  const reportCount = workflowCount * populationCount * deploymentAge * DEFAULTS.DOCS_PER_POP_WORKFLOW_YEAR;
+  const reportCount = workflowCount * populationCount * deploymentAge * docsPerWorkflowYear;
   const totalDocCount = contactCount + reportCount;
   const dbDiskGb = Math.max(1, Math.ceil(totalDocCount / DEFAULTS.MEDIC_DOCS_PER_GB));
   const diskOverprovisionGb = dbDiskGb * dbOverprovisionFactor;
@@ -84,7 +88,8 @@ const calculateMetrics = (els) => {
   const popPerUser = userCount > 0 ? populationCount / userCount : 0;
   return {
     cpuCount, ramGb, instanceCost, dbDiskGb, diskOverprovisionGb, rootVolumeGb, diskSizeGb,
-    diskCost, totalCost, totalDocCount, popPerUser, docsPerUser, dbOverprovisionFactor, userCount
+    diskCost, totalCost, totalDocCount, popPerUser, docsPerUser, dbOverprovisionFactor,
+    docsPerWorkflowYear, userCount
   };
 };
 
@@ -144,6 +149,7 @@ const updateOutputElements = (els) => () => {
   }
 
   els.dbOverprovision.value = m.dbOverprovisionFactor;
+  els.docsPerWorkflow.value = m.docsPerWorkflowYear;
 };
 
 const applyInputConfig = ({ value, ...attrs }, ...inputs) => {
@@ -189,6 +195,7 @@ const attachListeners = (els, debounced, updateOutputs) => {
 
   addAdvancedInput(els.deploymentAgeValue, debounced, updateOutputs);
   addAdvancedInput(els.dbOverprovision, debounced, updateOutputs);
+  addAdvancedInput(els.docsPerWorkflow, debounced, updateOutputs);
 
   const toggleParameters = (showAdvanced) => {
     els.basicParams.classList.toggle('calc-hidden', showAdvanced);
@@ -199,6 +206,7 @@ const attachListeners = (els, debounced, updateOutputs) => {
   els.resetAdvanced?.addEventListener('click', () => {
     els.deploymentAgeValue.value = UI_CONSTANTS.DEPLOYMENT_AGE.value;
     els.dbOverprovision.value = UI_CONSTANTS.DB_OVERPROVISION.value;
+    els.docsPerWorkflow.value = UI_CONSTANTS.DOCS_PER_WORKFLOW.value;
     updateOutputs();
   });
 };
@@ -216,6 +224,7 @@ const initCostCalculator = (calcId) => {
     userCountInputValue: el('user-count-input-value'),
     deploymentAgeValue: el('deployment-age-value'),
     dbOverprovision: el('db-overprovision'),
+    docsPerWorkflow: el('docs-per-workflow'),
     resetAdvanced: el('reset-advanced'),
     basicParams: el('basic-params'),
     advancedParams: el('advanced-params'),
@@ -252,6 +261,7 @@ const initCostCalculator = (calcId) => {
   applyInputConfig(UI_CONSTANTS.USERS, els.userCountInput, els.userCountInputValue);
   applyInputConfig(UI_CONSTANTS.DEPLOYMENT_AGE, els.deploymentAgeValue);
   applyInputConfig(UI_CONSTANTS.DB_OVERPROVISION, els.dbOverprovision);
+  applyInputConfig(UI_CONSTANTS.DOCS_PER_WORKFLOW, els.docsPerWorkflow);
 
   const updateOutputs = updateOutputElements(els);
   const debounced = debouncedUpdate(updateOutputs);

--- a/assets/js/cost-calculator.js
+++ b/assets/js/cost-calculator.js
@@ -3,7 +3,6 @@ const DEFAULTS = {
   MEDIC_DOCS_PER_GB: 186089,
   MEDIC_DOCS_PER_USER_BASELINE: 8717,
   PLACES_PER_POP: 0.36,
-  USERS_PER_CPU: 288,
   RAM_PER_CPU: 2,
   COST_PER_CPU_MONTH: 20.85,
   ROOT_VOLUME_GB: 50
@@ -18,6 +17,7 @@ const UI_CONSTANTS = {
   DEPLOYMENT_AGE: { value: 1, min: 1, max: 10 },
   DB_OVERPROVISION: { value: 5, min: 1, max: 10 },
   DOCS_PER_WORKFLOW: { value: 1, min: 1, max: 100 },
+  USERS_PER_CPU: { value: 288, min: 1, max: 1000 },
 };
 
 const formatCurrency = (amount, opts = {}) => amount.toLocaleString(navigator.language, {
@@ -70,6 +70,10 @@ const calculateMetrics = (els) => {
     1,
     Number.parseInt(els.docsPerWorkflow?.value || UI_CONSTANTS.DOCS_PER_WORKFLOW.value)
   );
+  const usersPerCpu = Math.max(
+    1,
+    Number.parseInt(els.usersPerCpu?.value || UI_CONSTANTS.USERS_PER_CPU.value)
+  );
   const placeCount = Math.floor(populationCount * DEFAULTS.PLACES_PER_POP);
   const contactCount = userCount + populationCount + placeCount;
   const reportCount = workflowCount * populationCount * deploymentAge * docsPerWorkflowYear;
@@ -81,7 +85,7 @@ const calculateMetrics = (els) => {
   const diskCost = DEFAULTS.DISK_COST_PER_GB_YEAR * diskSizeGb;
   const docsPerUser = userCount > 0 ? totalDocCount / userCount : 0;
   const cpuCountFactor = Math.max(1, docsPerUser / DEFAULTS.MEDIC_DOCS_PER_USER_BASELINE);
-  const cpuCount = Math.max(1, Math.ceil((userCount * cpuCountFactor) / DEFAULTS.USERS_PER_CPU));
+  const cpuCount = Math.max(1, Math.ceil((userCount * cpuCountFactor) / usersPerCpu));
   const ramGb = cpuCount * DEFAULTS.RAM_PER_CPU;
   const instanceCost = cpuCount * DEFAULTS.COST_PER_CPU_MONTH * 12;
   const totalCost = diskCost + instanceCost;
@@ -89,7 +93,7 @@ const calculateMetrics = (els) => {
   return {
     cpuCount, ramGb, instanceCost, dbDiskGb, diskOverprovisionGb, rootVolumeGb, diskSizeGb,
     diskCost, totalCost, totalDocCount, popPerUser, docsPerUser, dbOverprovisionFactor,
-    docsPerWorkflowYear, userCount
+    docsPerWorkflowYear, usersPerCpu, userCount
   };
 };
 
@@ -150,6 +154,7 @@ const updateOutputElements = (els) => () => {
 
   els.dbOverprovision.value = m.dbOverprovisionFactor;
   els.docsPerWorkflow.value = m.docsPerWorkflowYear;
+  els.usersPerCpu.value = m.usersPerCpu;
 };
 
 const applyInputConfig = ({ value, ...attrs }, ...inputs) => {
@@ -196,6 +201,7 @@ const attachListeners = (els, debounced, updateOutputs) => {
   addAdvancedInput(els.deploymentAgeValue, debounced, updateOutputs);
   addAdvancedInput(els.dbOverprovision, debounced, updateOutputs);
   addAdvancedInput(els.docsPerWorkflow, debounced, updateOutputs);
+  addAdvancedInput(els.usersPerCpu, debounced, updateOutputs);
 
   const toggleParameters = (showAdvanced) => {
     els.basicParams.classList.toggle('calc-hidden', showAdvanced);
@@ -207,6 +213,7 @@ const attachListeners = (els, debounced, updateOutputs) => {
     els.deploymentAgeValue.value = UI_CONSTANTS.DEPLOYMENT_AGE.value;
     els.dbOverprovision.value = UI_CONSTANTS.DB_OVERPROVISION.value;
     els.docsPerWorkflow.value = UI_CONSTANTS.DOCS_PER_WORKFLOW.value;
+    els.usersPerCpu.value = UI_CONSTANTS.USERS_PER_CPU.value;
     updateOutputs();
   });
 };
@@ -225,6 +232,7 @@ const initCostCalculator = (calcId) => {
     deploymentAgeValue: el('deployment-age-value'),
     dbOverprovision: el('db-overprovision'),
     docsPerWorkflow: el('docs-per-workflow'),
+    usersPerCpu: el('users-per-cpu'),
     resetAdvanced: el('reset-advanced'),
     basicParams: el('basic-params'),
     advancedParams: el('advanced-params'),
@@ -262,6 +270,7 @@ const initCostCalculator = (calcId) => {
   applyInputConfig(UI_CONSTANTS.DEPLOYMENT_AGE, els.deploymentAgeValue);
   applyInputConfig(UI_CONSTANTS.DB_OVERPROVISION, els.dbOverprovision);
   applyInputConfig(UI_CONSTANTS.DOCS_PER_WORKFLOW, els.docsPerWorkflow);
+  applyInputConfig(UI_CONSTANTS.USERS_PER_CPU, els.usersPerCpu);
 
   const updateOutputs = updateOutputElements(els);
   const debounced = debouncedUpdate(updateOutputs);

--- a/assets/js/cost-calculator.js
+++ b/assets/js/cost-calculator.js
@@ -1,6 +1,7 @@
 const DEFAULTS = {
   DISK_COST_PER_GB_YEAR: 0.96,
   MEDIC_DOCS_PER_GB: 186089,
+  MEDIC_DOCS_PER_USER_BASELINE: 8717,
   PLACES_PER_POP: 0.36,
   USERS_PER_CPU: 288,
   RAM_PER_CPU: 2,
@@ -74,12 +75,13 @@ const calculateMetrics = (els) => {
   const rootVolumeGb = DEFAULTS.ROOT_VOLUME_GB;
   const diskSizeGb = dbDiskGb + diskOverprovisionGb + rootVolumeGb;
   const diskCost = DEFAULTS.DISK_COST_PER_GB_YEAR * diskSizeGb;
-  const cpuCount = Math.max(1, Math.ceil(userCount / DEFAULTS.USERS_PER_CPU));
+  const docsPerUser = userCount > 0 ? totalDocCount / userCount : 0;
+  const cpuCountFactor = Math.max(1, docsPerUser / DEFAULTS.MEDIC_DOCS_PER_USER_BASELINE);
+  const cpuCount = Math.max(1, Math.ceil((userCount * cpuCountFactor) / DEFAULTS.USERS_PER_CPU));
   const ramGb = cpuCount * DEFAULTS.RAM_PER_CPU;
   const instanceCost = cpuCount * DEFAULTS.COST_PER_CPU_MONTH * 12;
   const totalCost = diskCost + instanceCost;
   const popPerUser = userCount > 0 ? populationCount / userCount : 0;
-  const docsPerUser = userCount > 0 ? totalDocCount / userCount : 0;
   return {
     cpuCount, ramGb, instanceCost, dbDiskGb, diskOverprovisionGb, rootVolumeGb, diskSizeGb,
     diskCost, totalCost, totalDocCount, popPerUser, docsPerUser, dbOverprovisionFactor, userCount

--- a/content/en/hosting/cht/costs.md
+++ b/content/en/hosting/cht/costs.md
@@ -12,6 +12,8 @@ aliases:
 
 This calculator provides an estimate of the monthly hosting costs for a CHT deployment. It is based on real-world data from production deployments and typical costs for hosting in a public cloud environment. See the details below for more information about how the costs are calculated.
 
+Note the ratios shown on the "Health Workers" panel. Tuning the calculator with unrealistic values (e.g., too large of a population for the number of health workers) will result in extreme numbers of people/docs per health worker. A sustainable CHT instance (both from a technical and a human perspective) should target realistic ratio values. 
+
 {{< cost-calculator >}}
 
 ### Calculation details
@@ -111,15 +113,23 @@ Items that are included in the basic costs of hosting the CHT:
 
 There are many additional costs to successfully hosting a CHT instance that are not included in this estimation:
 
-* Backups - Regular snapshots of the production data will need to be taken to ensure there is no data loss in case of catastrophic failure of server hardware. This takes up a disk space which should be accounted for when budgeting to host the CHT.
-* [Monitoring and Alerting](/technical-overview/architecture/cht-watchdog/) - Since all software fails eventually, you need to be prepared to defend against this with aggressive monitoring and alerting. The goal will be to fix the problem before any users notice.
-* Training of Systems Administrators/IT - System administrator IT systems that have not hosted the CHT will need to be trained.
-* Training of Trainers (ToT) and user Training
+Hardware:
+
 * Data Warehousing & Dashboards – Many deployments require a data warehouse ([CHT Sync](/technical-overview/architecture/cht-sync/) + Postgres) and dashboards (Superset/Klipfolio). However, this is not strictly required to host a CHT instance and can be added at a later date.
 * Upfront Purchase of Hardware – It is assumed that a deployment will either be using cloud-based solutions or using managed bare metal, so these costs are not included.
-* App Development – Each deployment needs to have the default CHT app customized for the required workflows.
 * Smartphones – Device purchase, setup, and distribution for users.
+
+Training/Maintenance:
+
+* Training of Systems Administrators/IT - System administrator IT systems that have not hosted the CHT will need to be trained.
+* Training of Trainers (ToT) and user Training
+* App Development – Each deployment needs to have the default CHT app customized for the required workflows.
 * Analog → Digital Workflow conversion – The process of documenting paper processes the CHT will replace.
+
+Services:
+
+* Backups - Regular snapshots of the production data will need to be taken to ensure there is no data loss in case of catastrophic failure of server hardware. This takes up a disk space which should be accounted for when budgeting to host the CHT.
+* [Monitoring and Alerting](/technical-overview/architecture/cht-watchdog/) - Since all software fails eventually, you need to be prepared to defend against this with aggressive monitoring and alerting. The goal will be to fix the problem before any users notice.
 * [SMS](/building/messaging/gateways/) – Some projects need the ability to send SMS to users from the CHT.
 * [Interoperability](/building/interoperability/) – While the CHT supports this out-of-the-box - development work can be necessary to ensure data exchange with specific third party systems.
 * Mobile Device Management - optional.

--- a/layouts/shortcodes/cost-calculator.html
+++ b/layouts/shortcodes/cost-calculator.html
@@ -56,6 +56,14 @@
           </div>
           <div class="helper-text">Multiplier for database storage headroom</div>
         </div>
+
+        <div class="advanced-input-group">
+          <div class="advanced-input">
+            <label>Reports Per Workflow</label>
+            <input type="number" class="input-value" data-calc="docs-per-workflow">
+          </div>
+          <div class="helper-text">Average number of reports generated per person for each workflow</div>
+        </div>
       </div>
 
       <div class="calc-divider advanced-footer">

--- a/layouts/shortcodes/cost-calculator.html
+++ b/layouts/shortcodes/cost-calculator.html
@@ -64,6 +64,14 @@
           </div>
           <div class="helper-text">Average number of reports generated per person for each workflow</div>
         </div>
+
+        <div class="advanced-input-group">
+          <div class="advanced-input">
+            <label>Users per CPU</label>
+            <input type="number" class="input-value" data-calc="users-per-cpu">
+          </div>
+          <div class="helper-text">Average numbers of users supported per CPU</div>
+        </div>
       </div>
 
       <div class="calc-divider advanced-footer">


### PR DESCRIPTION
# Description

Based on feedback [on slack](https://medic.slack.com/archives/C024KTGRW/p1774889431388059), I have made several changes to the Hosting Cost Calculator:

- I have added some copy to the page to provide a bit of context regarding the ratios on the Health Workers panel (guiding folks to more realistic numbers).
- I added some new logic that ties the CPU/RAM requirements to the number of docs (and not just the number of users). So, as you increase the Population/Workflows sliders, you will also increase the requirements for CPU/RAM.
  - The logic here is based on the docs-per-user (with the idea that if your average number of docs per user is too high, it will also impact CPU/RAM when syncing).
  - Basically if your number of docs per user is above the baseline (`8717` - calculated as an average-ish docs per user [for production instances](https://docs.google.com/spreadsheets/d/1OgJ-szJjHCd8fFjdn_nzGKWN9H0rp6xczR7gpP2mLk8/edit?usp=sharing)) then we start increasing the "number" of users that you have to provide CPU for.
  - It is not super scientific, but given our recent findings about the performance implications of high-doc users, it is probably still erring on the low side...
- I have also added new "Advanced Parameters" for docs per workflow and users per CPU. These were both customizations that were specifically requested (on the slack thread).

I did not make any visual changes to the layout (besides the new elements on "Advanced Parameters").

## AI Disclosure

Claude did most of the heavy lifting here, but I wrote all the copy and carefully reviewed the code changes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

