### PR TITLE
chore(na): update link checker cron CI from 15min to 60min timeout

### DIFF
--- a/.github/workflows/cron-check-links.yml
+++ b/.github/workflows/cron-check-links.yml
@@ -19,7 +19,7 @@ jobs:
   BuildLinkCheckPushLive:
     name:
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 60
     steps:
 
       - name: Git checkout cht-docs repos


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

update link checker cron CI from 15min to 60min timeout per timeouts [seen in](https://github.com/medic/cht-docs/actions/runs/29731193742) CI:

```
Status Cancelled
Total duration 15m 7s

BuildLinkCheckPushLive
The job has exceeded the maximum execution time of 15m0s

BuildLinkCheckPushLive
The operation was canceled.
```

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

