### PR TITLE
some slim linux distros don't have bzip2

### DIFF
--- a/content/en/community/contributing/code/core/dev-environment.md
+++ b/content/en/community/contributing/code/core/dev-environment.md
@@ -193,7 +193,6 @@ If you had issues with following the above steps, check out these links for how 
 * [python 2.7](https://www.python.org/downloads/)
 * [Docker](https://docs.docker.com/engine/install/)
 * [CouchDB](https://docs.couchdb.org/en/stable/install/index.html) - OS package instead of in Docker - you **MUST** use CouchDB 2.x for CHT < 4.4! We still strongly recommend using Docker.
-* [bzip2])(https://sourceware.org/bzip2/downloads.html) - if you're on Ubuntu call: `sudo apt install bzip2`
 
 ### Windows WSL2
 

--- a/content/en/community/contributing/code/core/dev-environment.md
+++ b/content/en/community/contributing/code/core/dev-environment.md
@@ -35,7 +35,7 @@ _(Node {{< param nodeVersion >}} is the environment used to run the CHT server i
   {{< tab >}}
 ```shell
   sudo apt update && sudo apt -y dist-upgrade
-  sudo apt -y install xsltproc curl uidmap jq python3 git make
+  sudo apt -y install xsltproc curl uidmap jq python3 git make bzip2
   # Use NVM to install NodeJS:
   export nvm_version=`curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r .name`
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_version/install.sh | $SHELL
@@ -58,7 +58,7 @@ _(Node {{< param nodeVersion >}} is the environment used to run the CHT server i
   {{< tab >}}
 ```shell
   sudo apt update && sudo apt -y dist-upgrade
-  sudo apt -y install xsltproc curl uidmap jq python3 git make
+  sudo apt -y install xsltproc curl uidmap jq python3 git make bzip2
   # Use NVM to install NodeJS:
   export nvm_version=`curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r .name`
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_version/install.sh | $SHELL


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Testing our core dev setup I found my [incus](https://linuxcontainers.org/incus/)  Ubuntu VM didn't have `bzip2` installed and I was getting an error when I called `npm run build-dev` per [the docs](https://docs.communityhealthtoolkit.org/community/contributing/code/core/dev-environment/#cht-core-cloning-and-setup):

```
npm error npm error Phantom installation failed Error: Command failed: tar jxf /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2                                                                 
npm error npm error tar (child): bzip2: Cannot exec: No such file or directory                   
npm error npm error tar (child): Error is not recoverable: exiting now                           
npm error npm error tar: Child returned status 2                                                                                                                                                   
npm error npm error tar: Error is not recoverable: exiting now                                   
npm error npm error                                                                                                                                                                                
npm error npm error     at genericNodeError (node:internal/errors:983:15)                                                                                                                          
npm error npm error     at wrappedFn (node:internal/errors:537:14)                               
npm error npm error     at ChildProcess.exithandler (node:child_process:417:12)                                                                                                                    
npm error npm error     at ChildProcess.emit (node:events:519:28)                                                                                                                                  
npm error npm error     at maybeClose (node:internal/child_process:1101:16)                      
npm error npm error     at Socket.<anonymous> (node:internal/child_process:456:11)               
npm error npm error     at Socket.emit (node:events:519:28)                                      
npm error npm error     at Pipe.<anonymous> (node:net:347:12) {
npm error npm error   code: 2,                                                                   
npm error npm error   killed: false,                                                             
npm error npm error   signal: null,                                                              
npm error npm error   cmd: 'tar jxf /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2'                                                                                                           
npm error npm error } Error: Command failed: tar jxf /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 
```


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

