### PR TITLE
fix(#2249): correct macOS Node, Python and CouchDB steps in dev guide

### DIFF
--- a/content/en/community/contributing/code/core/dev-environment.md
+++ b/content/en/community/contributing/code/core/dev-environment.md
@@ -48,9 +48,11 @@ _(Node {{< param nodeVersion >}} is the environment used to run the CHT server i
   # Uses Homebrew: https://brew.sh/
   brew update
   brew install curl jq pyenv git make node@{{< param nodeVersion >}}
-  # Python no longer included by default in macOS >12.3 
-  pyenv install 2.7.18
-  pyenv global 2.7.18
+  # node@{{< param nodeVersion >}} is keg-only, so Homebrew does not symlink it onto your PATH.
+  echo "export PATH=\"\$(brew --prefix node@{{< param nodeVersion >}})/bin:\$PATH\"" >> ~/.$(basename $SHELL)rc
+  # Python is no longer included by default in macOS >12.3
+  pyenv install 3.10.13
+  pyenv global 3.10.13
   echo "eval \"\$(pyenv init --path)\"" >> ~/.$(basename $SHELL)rc
   . ~/.$(basename $SHELL)rc
 ```
@@ -74,6 +76,10 @@ Now let's ensure NodeJS {{< param nodeVersion >}} and npm {{< param npmVersion >
 ```shell
 node -v && npm -v
 ```
+
+{{< callout type="warning" >}}
+On macOS, `node@{{< param nodeVersion >}}` is [keg-only](https://docs.brew.sh/FAQ#what-does-keg-only-mean) — installing it does not put it on your PATH. If the command above reports any version other than {{< param nodeVersion >}}.x.x, the `export PATH` line from the macOS tab has not taken effect; open a new shell, or re-run it, before continuing. Everything below will otherwise silently build and run against the wrong version of Node.
+{{< /callout >}}
 
 Install Docker:
 
@@ -166,7 +172,14 @@ cd ~/cht-core && npm run dev-sentinel
 
 That's it!  Now when you edit code in your IDE, it will automatically reload.  You can see the CHT running locally here: [http://localhost:5988/](http://localhost:5988/)
 
-When you're done with development you can `ctrl + c` in the three terminals and stop the CouchDB container with `docker stop medic-couchdb`.  When you want to resume development later, run `docker start medic-couchdb` and re-run the three terminal commands.
+When you're done with development you can `ctrl + c` in the three terminals and stop the CouchDB containers with:
+
+```shell
+cd ~/cht-docker
+COUCHDB_USER=medic COUCHDB_PASSWORD=password docker compose -f docker-compose.yml -f couchdb-override.yml stop
+```
+
+When you want to resume development later, run the same command with `start` in place of `stop`, then re-run the three terminal commands. The `COUCHDB_*` variables are required because `docker-compose.yml` declares `COUCHDB_PASSWORD` as mandatory; without them `docker compose` aborts before it reaches the container.
 
 ### Adding and accessing data
 
@@ -190,10 +203,10 @@ If you had issues with following the above steps, check out these links for how 
 
 * [Node.js {{< param nodeVersion >}}.x](https://nodejs.org/) & [npm {{< param npmVersion >}}.x.x](https://npmjs.com/) - Both of which we recommend installing [via `nvm`](https://github.com/nvm-sh/nvm#installing-and-updating)
 * [xsltproc](https://github.com/ilyar/xsltproc) 
-* [python 2.7](https://www.python.org/downloads/)
+* [python 3](https://www.python.org/downloads/)
 * [Docker](https://docs.docker.com/engine/install/)
 * [CouchDB](https://docs.couchdb.org/en/stable/install/index.html) - OS package instead of in Docker - you **MUST** use CouchDB 2.x for CHT < 4.4! We still strongly recommend using Docker.
-* [bzip2])(https://sourceware.org/bzip2/downloads.html) - if you're on Ubuntu call: `sudo apt install bzip2`
+* [bzip2](https://sourceware.org/bzip2/downloads.html) - if you're on Ubuntu call: `sudo apt install bzip2`
 
 ### Windows WSL2
 

--- a/content/en/community/contributing/code/core/dev-environment.md
+++ b/content/en/community/contributing/code/core/dev-environment.md
@@ -35,7 +35,7 @@ _(Node {{< param nodeVersion >}} is the environment used to run the CHT server i
   {{< tab >}}
 ```shell
   sudo apt update && sudo apt -y dist-upgrade
-  sudo apt -y install xsltproc curl uidmap jq python3 git make
+  sudo apt -y install xsltproc curl uidmap jq python3 git make bzip2
   # Use NVM to install NodeJS:
   export nvm_version=`curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r .name`
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_version/install.sh | $SHELL
@@ -60,7 +60,7 @@ _(Node {{< param nodeVersion >}} is the environment used to run the CHT server i
   {{< tab >}}
 ```shell
   sudo apt update && sudo apt -y dist-upgrade
-  sudo apt -y install xsltproc curl uidmap jq python3 git make
+  sudo apt -y install xsltproc curl uidmap jq python3 git make bzip2
   # Use NVM to install NodeJS:
   export nvm_version=`curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r .name`
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_version/install.sh | $SHELL
@@ -78,7 +78,7 @@ node -v && npm -v
 ```
 
 {{< callout type="warning" >}}
-On macOS, `node@{{< param nodeVersion >}}` is [keg-only](https://docs.brew.sh/FAQ#what-does-keg-only-mean) — installing it does not put it on your PATH. If the command above reports any version other than {{< param nodeVersion >}}.x.x, the `export PATH` line from the macOS tab has not taken effect; open a new shell, or re-run it, before continuing. Everything below will otherwise silently build and run against the wrong version of Node.
+On macOS, `node@{{< param nodeVersion >}}` is [keg-only](https://docs.brew.sh/FAQ#what-does-keg-only-mean) so it doesn't end up in your `PATH`. If `node -v` shows a different version than {{< param nodeVersion >}}.x.x, the `export PATH` line from the macOS tab has not taken effect. To fix this,  open a new shell, or re-run `export PATH`, before continuing.
 {{< /callout >}}
 
 Install Docker:
@@ -206,7 +206,6 @@ If you had issues with following the above steps, check out these links for how 
 * [python 3](https://www.python.org/downloads/)
 * [Docker](https://docs.docker.com/engine/install/)
 * [CouchDB](https://docs.couchdb.org/en/stable/install/index.html) - OS package instead of in Docker - you **MUST** use CouchDB 2.x for CHT < 4.4! We still strongly recommend using Docker.
-* [bzip2](https://sourceware.org/bzip2/downloads.html) - if you're on Ubuntu call: `sudo apt install bzip2`
 
 ### Windows WSL2
 

--- a/content/en/community/contributing/code/core/dev-environment.md
+++ b/content/en/community/contributing/code/core/dev-environment.md
@@ -56,6 +56,9 @@ _(Node {{< param nodeVersion >}} is the environment used to run the CHT server i
   echo "eval \"\$(pyenv init --path)\"" >> ~/.$(basename $SHELL)rc
   . ~/.$(basename $SHELL)rc
 ```
+  {{< callout type="warning" >}}
+  On macOS, `node@{{< param nodeVersion >}}` is [keg-only](https://docs.brew.sh/FAQ#what-does-keg-only-mean) so it doesn't end up in your `PATH`. If `node -v` call below shows a different version than {{< param nodeVersion >}}.x.x, the `export PATH` line from the macOS tab has not taken effect. To fix this,  open a new shell, or re-run `export PATH`, before continuing.
+  {{< /callout >}}
   {{< /tab >}}
   {{< tab >}}
 ```shell
@@ -77,9 +80,6 @@ Now let's ensure NodeJS {{< param nodeVersion >}} and npm {{< param npmVersion >
 node -v && npm -v
 ```
 
-{{< callout type="warning" >}}
-On macOS, `node@{{< param nodeVersion >}}` is [keg-only](https://docs.brew.sh/FAQ#what-does-keg-only-mean) so it doesn't end up in your `PATH`. If `node -v` shows a different version than {{< param nodeVersion >}}.x.x, the `export PATH` line from the macOS tab has not taken effect. To fix this,  open a new shell, or re-run `export PATH`, before continuing.
-{{< /callout >}}
 
 Install Docker:
 


### PR DESCRIPTION
# Description

Fixes #2249

Five steps in the CHT Core dev environment guide are wrong on macOS. I hit all five following the guide end to end today on macOS 26.3.1 (Apple Silicon); each fix is one I ran rather than reasoned about.

**1. `node@{{< param nodeVersion >}}` is keg-only, so the install step doesn't take effect.** Homebrew does not symlink keg-only formulae onto the PATH, so after the macOS tab's `brew install`, `node` is still whatever it was before. Adds the `export PATH` line, and gives the `node -v && npm -v` verification an explicit failure branch — as written it prints the wrong version and reports nothing wrong, so the reader goes on to build and run everything against the wrong Node.

**2 & 3. `pyenv global 2.7.18` pins an EOL Python the repo cannot use**, in the macOS tab and again in the prerequisites list. The only Python tooling in `cht-core` is `haproxy-healthcheck/`, whose `Makefile` runs `python3 -m venv .venv` and whose `.tool-versions` declares `python 3.10.13`. The Linux and WSL2 tabs of this same guide install `python3`.

**4. `docker stop medic-couchdb` names a container that is never created.** The `docker-compose.yml` this guide downloads creates `cht-docker-couchdb-1` and `cht-docker-nouveau-1`, so the documented command fails with `No such container`, and correcting only the name would still leave `nouveau` running. Replaces stop and start with the compose equivalents. They need the `COUCHDB_*` prefix because the compose file marks `COUCHDB_PASSWORD` mandatory with `:?` — without it `docker compose` aborts during interpolation.

**5. Malformed markdown link** on the `bzip2` prerequisite — `])(` should be `](`.

### How this was verified

| Claim | How it was checked |
|---|---|
| `node@22` is keg-only | `brew info node@22` → `[keg-only]`, "was not symlinked into /opt/homebrew" |
| The verify step passes on the wrong Node | Ran the macOS tab verbatim; `node -v` reported 26.4.0, not 22.x.x |
| Nothing needs Python 2 | `python2` absent from the machine; `npm ci` (3439 pkgs), `npm run build-dev` and `npm run dev-api` all completed clean |
| `.tool-versions` asks for 3.10.13 | Read `haproxy-healthcheck/.tool-versions` |
| `docker stop medic-couchdb` fails | Ran it: `Error response from daemon: No such container: medic-couchdb` |
| Bare `docker compose stop` fails | Ran it: `required variable COUCHDB_PASSWORD is missing a value` |
| The replacement commands work | Full round trip — `stop` → both containers `Exited (143)` → `start` → both `Up` → CouchDB answering on 5984 |
| `callout type="warning"` renders | Theme is Hextra; `callout type` already used in three other `content/en` pages |

### Not in this PR

#2249 also lists six **improvements** — a `.env` for the CouchDB credentials, a link to the automated-tests page, a note about the hardcoded `~/cht-core` paths, where the CouchDB data lives, a question about `| $SHELL` in the Linux nvm install, and the missing `.nvmrc` in cht-core. I've deliberately kept them out of this PR so the fixes can land on their own. Happy to add any of them here or in a follow-up — your call.

### What I did not verify

Only the macOS path. I have no Linux or WSL2 machine, so I have not confirmed those tabs are unaffected — I believe they are, since neither uses Homebrew or `pyenv`. I also did not run the e2e or integration suites, so the Python 2 claim is scoped to the setup this guide walks through rather than to the whole repo. I have not built the site locally to view the rendered page.

### AI disclosure

Claude Code (Anthropic) was used to run the setup, reproduce each failure, test the replacement commands, and draft this PR. Every command in the table above was executed and its output read. I have reviewed the change and am accountable for it. — Ken Britton

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
