### PR TITLE
feat(#2257): order docs/forum results first in Kapa search

### DIFF
--- a/layouts/partials/custom/head-end.html
+++ b/layouts/partials/custom/head-end.html
@@ -47,6 +47,7 @@
   data-modal-open-on-command-k="false"
   data-modal-border-radius="6px"
   data-search-mode-enabled="true"
+  data-search-source-ids-order="1af28c7b-d8b4-485c-a8bf-98b4ba246ad9,d7dd5893-1101-432a-b240-259014d66800"
   data-button-hide="true"
 ></script>
 


### PR DESCRIPTION
# Description

Closes https://github.com/medic/cht-docs/issues/2257

According to the Kapa [search config docs](https://docs.kapa.ai/integrations/website-widget/configuration/behavior#search-configuration) we can set the `data-search-source-ids-order` property to configure the _order_ we want the search results to show up in.  The id values we provide are our [Kappa AI Sources](https://app.kapa.ai/1cc25d03-dcd0-4c75-9a3e-8fe3443da795/sources) (so docs, forum, cht-core files, cht-core issues, etc.  

In this PR I have just set the ordering so the Docs results show first, followed by the forum results, followed by everything else.  (Happy to adjust this as seems appropriate).

<img width="1354" height="1434" alt="image" src="https://github.com/user-attachments/assets/d7aeb09c-b755-4e08-b1a2-da23356b33f4" />

## Alternatives

As you can see in the docs, there are several other properties we _could_ set to further tune the experience. The most relevant of which is `data-search-source-ids-include` (or `data-source-group-ids-include`).  With these properties we could filter exactly which sources we show results for on the search page.  (E.g. only show Docs/Forum and never show code.  Or even, show code, but not issues, or vice-versa.)

Because all of this is just an api call to Kappa, we can test different combos locally and see which results we like before pushing to prod...  :+1: 

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

